### PR TITLE
Fixed outdated gocheck import

### DIFF
--- a/args_test.go
+++ b/args_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/juju/testing"
 	"launchpad.net/gnuflag"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/cmd"
 )

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"

--- a/cmdtesting/cmd.go
+++ b/cmdtesting/cmd.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 
 	"launchpad.net/gnuflag"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/cmd"
 )

--- a/filevar_test.go
+++ b/filevar_test.go
@@ -11,7 +11,7 @@ import (
 	gitjujutesting "github.com/juju/testing"
 	"github.com/juju/utils"
 	"launchpad.net/gnuflag"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"

--- a/logging_test.go
+++ b/logging_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/juju/loggo"
 	"github.com/juju/testing"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 	"github.com/juju/cmd/cmdtesting"
 
 	"github.com/juju/cmd"

--- a/names_test.go
+++ b/names_test.go
@@ -4,7 +4,7 @@
 package cmd_test
 
 import (
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/cmd"
 )

--- a/output_test.go
+++ b/output_test.go
@@ -5,7 +5,7 @@ package cmd_test
 
 import (
 	"launchpad.net/gnuflag"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"

--- a/package_test.go
+++ b/package_test.go
@@ -6,7 +6,7 @@ package cmd_test
 import (
 	stdtesting "testing"
 
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 func TestPackage(t *stdtesting.T) {

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -10,7 +10,7 @@ import (
 
 	gitjujutesting "github.com/juju/testing"
 	"launchpad.net/gnuflag"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"

--- a/version_test.go
+++ b/version_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"fmt"
 
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 type VersionSuite struct{}


### PR DESCRIPTION
This PR changes the import of gocheck from launchpad to github.
