### PR TITLE
add support for outputting time in yaml formatters

### DIFF
--- a/output.go
+++ b/output.go
@@ -12,7 +12,7 @@ import (
 	"sort"
 	"strings"
 
-	goyaml "gopkg.in/yaml.v1"
+	goyaml "gopkg.in/yaml.v2"
 	"launchpad.net/gnuflag"
 )
 
@@ -72,6 +72,7 @@ func FormatSmart(value interface{}) ([]byte, error) {
 	case reflect.Map, reflect.Float32, reflect.Float64:
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+	case reflect.Struct:
 	default:
 		return nil, fmt.Errorf("cannot marshal %#v", value)
 	}

--- a/output_test.go
+++ b/output_test.go
@@ -4,6 +4,8 @@
 package cmd_test
 
 import (
+	"time"
+
 	gc "gopkg.in/check.v1"
 	"launchpad.net/gnuflag"
 
@@ -59,6 +61,7 @@ var outputTests = map[string][]struct {
 		{false, "False\n"},
 		{"hello", "hello\n"},
 		{"\n\n\n", "\n\n\n\n"},
+		{time.Date(2014, time.November, 27, 0, 0, 0, 0, time.UTC), "2014-11-27T00:00:00Z\n"},
 		{"foo: bar", "foo: bar\n"},
 		{[]string{"blam", "dink"}, "blam\ndink\n"},
 		{map[interface{}]interface{}{"foo": "bar"}, "foo: bar\n"},
@@ -73,6 +76,7 @@ var outputTests = map[string][]struct {
 		{false, "False\n"},
 		{"hello", "hello\n"},
 		{"\n\n\n", "\n\n\n\n"},
+		{time.Date(2014, time.November, 27, 0, 0, 0, 0, time.UTC), "2014-11-27T00:00:00Z\n"},
 		{"foo: bar", "foo: bar\n"},
 		{[]string{"blam", "dink"}, "blam\ndink\n"},
 		{[2]string{"blam", "dink"}, "blam\ndink\n"},
@@ -88,6 +92,7 @@ var outputTests = map[string][]struct {
 		{false, "false\n"},
 		{"hello", `"hello"` + "\n"},
 		{"\n\n\n", `"\n\n\n"` + "\n"},
+		{time.Date(2014, time.November, 27, 0, 0, 0, 0, time.UTC), `"2014-11-27T00:00:00Z"` + "\n"},
 		{"foo: bar", `"foo: bar"` + "\n"},
 		{[]string{}, `[]` + "\n"},
 		{[]string{"blam", "dink"}, `["blam","dink"]` + "\n"},
@@ -103,6 +108,7 @@ var outputTests = map[string][]struct {
 		{false, "false\n"},
 		{"hello", "hello\n"},
 		{"\n\n\n", "'\n\n\n\n'\n"},
+		{time.Date(2014, time.November, 27, 0, 0, 0, 0, time.UTC), "2014-11-27T00:00:00Z\n"},
 		{"foo: bar", "'foo: bar'\n"},
 		{[]string{"blam", "dink"}, "- blam\n- dink\n"},
 		{defaultValue, "juju: 1\npuppet: false\n"},


### PR DESCRIPTION
It would be useful if yaml output supported printing time as a string