### PR TITLE
Correct licence header is supercommand_test.go to LGPLv3

### DIFF
--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -1,5 +1,5 @@
 // Copyright 2012, 2013 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package cmd_test
 


### PR DESCRIPTION
Correct a missed licence header from AGPL to LGPL as noted by ubuntu release review:

https://bugs.launchpad.net/juju-core/+bug/1442132

(Review request: http://reviews.vapour.ws/r/1413/)