### PR TITLE
Add environment variables support to Context.

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -91,6 +91,7 @@ func (c *CommandBase) AllowInterspersedFlags() bool {
 // output and errors to Stdout and Stderr respectively.
 type Context struct {
 	Dir     string
+	Env     map[string]string
 	Stdin   io.Reader
 	Stdout  io.Writer
 	Stderr  io.Writer
@@ -124,6 +125,22 @@ func (ctx *Context) Verbosef(format string, params ...interface{}) {
 	} else {
 		logger.Infof(format, params...)
 	}
+}
+
+// Getenv looks up an environment variable in the context. It mirrors
+// os.Getenv. An empty string is returned if the key is not set.
+func (ctx *Context) Getenv(key string) string {
+	value, _ := ctx.Env[key]
+	return value
+}
+
+// Setenv sets an environment variable in the context. It mirrors os.Setenv.
+func (ctx *Context) Setenv(key, value string) error {
+	if ctx.Env == nil {
+		ctx.Env = make(map[string]string)
+	}
+	ctx.Env[key] = value
+	return nil
 }
 
 // AbsPath returns an absolute representation of path, with relative paths

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -24,6 +24,27 @@ func (s *CmdSuite) TestContext(c *gc.C) {
 	c.Assert(ctx.AbsPath("foo/bar"), gc.Equals, filepath.Join(ctx.Dir, "foo/bar"))
 }
 
+func (s *CmdSuite) TestContextGetenv(c *gc.C) {
+	ctx := cmdtesting.Context(c)
+	ctx.Env = make(map[string]string)
+	before := ctx.Getenv("foo")
+	ctx.Env["foo"] = "bar"
+	after := ctx.Getenv("foo")
+
+	c.Check(before, gc.Equals, "")
+	c.Check(after, gc.Equals, "bar")
+}
+
+func (s *CmdSuite) TestContextSetenv(c *gc.C) {
+	ctx := cmdtesting.Context(c)
+	before := ctx.Env["foo"]
+	ctx.Setenv("foo", "bar")
+	after := ctx.Env["foo"]
+
+	c.Check(before, gc.Equals, "")
+	c.Check(after, gc.Equals, "bar")
+}
+
 func (s *CmdSuite) TestInfo(c *gc.C) {
 	minimal := &TestCommand{Name: "verb", Minimal: true}
 	help := minimal.Info().Help(cmdtesting.NewFlagSet())


### PR DESCRIPTION
This allows commands to be run with a customized OS environment.

(Review request: http://reviews.vapour.ws/r/2117/)