### PR TITLE
Revert "Switch to using gopkg.in/yaml.v2"

### DIFF
--- a/output.go
+++ b/output.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"strings"
 
-	goyaml "gopkg.in/yaml.v2"
+	goyaml "gopkg.in/yaml.v1"
 	"launchpad.net/gnuflag"
 )
 


### PR DESCRIPTION
Reverts juju/cmd#22

Breaks github.com/juju/juju/cmd/juju/status, the handling of empty fields is different between these versions.

(Review request: http://reviews.vapour.ws/r/2945/)