### PR TITLE
Add the ability for a supercommand to specify an alias file.

### DIFF
--- a/aliasfile.go
+++ b/aliasfile.go
@@ -1,0 +1,49 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENSE file for details.
+
+package cmd
+
+import (
+	"io/ioutil"
+	"strings"
+)
+
+func ParseAliasFile(aliasFilename string) map[string][]string {
+	result := map[string][]string{}
+	if aliasFilename == "" {
+		return result
+	}
+
+	content, err := ioutil.ReadFile(aliasFilename)
+	if err != nil {
+		logger.Tracef("unable to read alias file %q: %s", aliasFilename, err)
+		return result
+	}
+
+	lines := strings.Split(string(content), "\n")
+	for i, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			// skip blank lines and comments
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			logger.Debugf("line %d bad in alias file: %s", i+1, line)
+			continue
+		}
+		name, value := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
+		if name == "" {
+			logger.Debugf("line %d missing alias name in alias file: %s", i+1, line)
+			continue
+		}
+		if value == "" {
+			logger.Debugf("line %d missing alias value in alias file: %s", i+1, line)
+			continue
+		}
+
+		logger.Tracef("setting alias %q=%q", name, value)
+		result[name] = strings.Fields(value)
+	}
+	return result
+}

--- a/aliasfile.go
+++ b/aliasfile.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 )
 
+// ParseAliasFile will read the specified file and convert
+// the content to a map of names to the command line arguments
+// they relate to.  The function will always return a valid map, even
+// if it is empty.
 func ParseAliasFile(aliasFilename string) map[string][]string {
 	result := map[string][]string{}
 	if aliasFilename == "" {
@@ -29,16 +33,16 @@ func ParseAliasFile(aliasFilename string) map[string][]string {
 		}
 		parts := strings.SplitN(line, "=", 2)
 		if len(parts) != 2 {
-			logger.Debugf("line %d bad in alias file: %s", i+1, line)
+			logger.Warningf("line %d bad in alias file: %s", i+1, line)
 			continue
 		}
 		name, value := strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1])
 		if name == "" {
-			logger.Debugf("line %d missing alias name in alias file: %s", i+1, line)
+			logger.Warningf("line %d missing alias name in alias file: %s", i+1, line)
 			continue
 		}
 		if value == "" {
-			logger.Debugf("line %d missing alias value in alias file: %s", i+1, line)
+			logger.Warningf("line %d missing alias value in alias file: %s", i+1, line)
 			continue
 		}
 

--- a/aliasfile_test.go
+++ b/aliasfile_test.go
@@ -32,15 +32,17 @@ func (*ParseAliasFileSuite) TestParse(c *gc.C) {
 	dir := c.MkDir()
 	filename := filepath.Join(dir, "missing")
 	content := `
-# comments skipped, as is the blank line at the start
-foo = bar
+# comments skipped, as are the blank lines, such as the line
+# at the start of this file
+   foo =  trailing-space    
 repeat = first
-flags = flags --with flag
+flags = flags  --with   flag
 
 # if the same alias name is used more than once, last one wins
 repeat = second
 
 # badly formated values are logged, but skipped
+no equals sign
 =
 key = 
 = value
@@ -49,7 +51,7 @@ key =
 	c.Assert(err, gc.IsNil)
 	aliases := cmd.ParseAliasFile(filename)
 	c.Assert(aliases, gc.DeepEquals, map[string][]string{
-		"foo":    []string{"bar"},
+		"foo":    []string{"trailing-space"},
 		"repeat": []string{"second"},
 		"flags":  []string{"flags", "--with", "flag"},
 	})

--- a/aliasfile_test.go
+++ b/aliasfile_test.go
@@ -1,0 +1,56 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENSE file for details.
+
+package cmd_test
+
+import (
+	_ "fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/cmd"
+)
+
+type ParseAliasFileSuite struct {
+	testing.LoggingSuite
+}
+
+var _ = gc.Suite(&ParseAliasFileSuite{})
+
+func (*ParseAliasFileSuite) TestMissing(c *gc.C) {
+	dir := c.MkDir()
+	filename := filepath.Join(dir, "missing")
+	aliases := cmd.ParseAliasFile(filename)
+	c.Assert(aliases, gc.NotNil)
+	c.Assert(aliases, gc.HasLen, 0)
+}
+
+func (*ParseAliasFileSuite) TestParse(c *gc.C) {
+	dir := c.MkDir()
+	filename := filepath.Join(dir, "missing")
+	content := `
+# comments skipped, as is the blank line at the start
+foo = bar
+repeat = first
+flags = flags --with flag
+
+# if the same alias name is used more than once, last one wins
+repeat = second
+
+# badly formated values are logged, but skipped
+=
+key = 
+= value
+`
+	err := ioutil.WriteFile(filename, []byte(content), 0644)
+	c.Assert(err, gc.IsNil)
+	aliases := cmd.ParseAliasFile(filename)
+	c.Assert(aliases, gc.DeepEquals, map[string][]string{
+		"foo":    []string{"bar"},
+		"repeat": []string{"second"},
+		"flags":  []string{"flags", "--with", "flag"},
+	})
+}


### PR DESCRIPTION
This will both allow users to specify custom user aliases, and also allow quick iteration over proposed CLI changes.

(Review request: http://reviews.vapour.ws/r/2970/)