### PR TITLE
Add an explicit option to not use aliases defined in the file.

### DIFF
--- a/supercommand.go
+++ b/supercommand.go
@@ -126,6 +126,7 @@ type SuperCommand struct {
 	showHelp            bool
 	showDescription     bool
 	showVersion         bool
+	noAlias             bool
 	missingCallback     MissingCallback
 	notifyRun           func(string)
 }
@@ -346,7 +347,10 @@ func (c *SuperCommand) SetFlags(f *gnuflag.FlagSet) {
 	// Any flags added below only take effect when no subcommand is
 	// specified (e.g. command --version).
 	if c.version != "" {
-		f.BoolVar(&c.showVersion, "version", false, "Show the command's version and exit")
+		f.BoolVar(&c.showVersion, "version", false, "show the command's version and exit")
+	}
+	if c.userAliasesFilename != "" {
+		f.BoolVar(&c.noAlias, "no-alias", false, "do not process command aliases when running this command")
 	}
 	c.flags = f
 }
@@ -369,7 +373,7 @@ func (c *SuperCommand) Init(args []string) error {
 		return c.action.command.Init(args)
 	}
 
-	if userAlias, found := c.userAliases[args[0]]; found {
+	if userAlias, found := c.userAliases[args[0]]; found && !c.noAlias {
 		logger.Debugf("using alias %q=%q", args[0], strings.Join(userAlias, " "))
 		args = append(userAlias, args[1:]...)
 	}

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -81,6 +81,10 @@ func (s *SuperCommandSuite) TestDispatch(c *gc.C) {
 	// --description must be used on it's own.
 	_, _, err = initDefenestrate([]string{"--description", "defenestrate"})
 	c.Assert(err, gc.ErrorMatches, `unrecognized args: \["defenestrate"\]`)
+
+	// --no-alias is not a valid option if there is no alias file speciifed
+	_, _, err = initDefenestrate([]string{"--no-alias", "defenestrate"})
+	c.Assert(err, gc.ErrorMatches, `flag provided but not defined: --no-alias`)
 }
 
 func (s *SuperCommandSuite) TestUserAliasDispatch(c *gc.C) {
@@ -104,6 +108,9 @@ func (s *SuperCommandSuite) TestUserAliasDispatch(c *gc.C) {
 	c.Assert(tc.Option, gc.Equals, "firmly")
 	info = jc.Info()
 	c.Assert(info.Name, gc.Equals, "jujutest defenestrate")
+
+	_, _, err = initDefenestrateWithAliases(c, []string{"--no-alias", "def"})
+	c.Assert(err, gc.ErrorMatches, "unrecognized command: jujutest def")
 
 	// Aliases to missing values are converted before lookup.
 	_, _, err = initDefenestrateWithAliases(c, []string{"other"})


### PR DESCRIPTION
Matches the bzr --no-alias command option.

(Review request: http://reviews.vapour.ws/r/2999/)