### PR TITLE
Update help text formatting

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -214,7 +214,7 @@ type Info struct {
 // flags defined in f. It calls f.SetOutput(ioutil.Discard).
 func (i *Info) Help(f *gnuflag.FlagSet) []byte {
 	buf := &bytes.Buffer{}
-	fmt.Fprintf(buf, "usage: %s", i.Name)
+	fmt.Fprintf(buf, "Usage: %s", i.Name)
 	hasOptions := false
 	f.VisitAll(func(f *gnuflag.Flag) { hasOptions = true })
 	if hasOptions {
@@ -225,19 +225,20 @@ func (i *Info) Help(f *gnuflag.FlagSet) []byte {
 	}
 	fmt.Fprintf(buf, "\n")
 	if i.Purpose != "" {
-		fmt.Fprintf(buf, "purpose: %s\n", i.Purpose)
+		fmt.Fprintf(buf, "\nSummary:\n%s\n", i.Purpose)
 	}
 	if hasOptions {
-		fmt.Fprintf(buf, "\noptions:\n")
+		fmt.Fprintf(buf, "\nOptions:\n")
 		f.SetOutput(buf)
 		f.PrintDefaults()
 	}
 	f.SetOutput(ioutil.Discard)
 	if i.Doc != "" {
-		fmt.Fprintf(buf, "\n%s\n", strings.TrimSpace(i.Doc))
+		fmt.Fprintf(buf, "\nDetails:\n")
+		fmt.Fprintf(buf, "%s\n", strings.TrimSpace(i.Doc))
 	}
 	if len(i.Aliases) > 0 {
-		fmt.Fprintf(buf, "\naliases: %s\n", strings.Join(i.Aliases, ", "))
+		fmt.Fprintf(buf, "\nAliases: %s\n", strings.Join(i.Aliases, ", "))
 	}
 	return buf.Bytes()
 }

--- a/help_test.go
+++ b/help_test.go
@@ -41,31 +41,31 @@ func (s *HelpCommandSuite) TestHelpOutput(c *gc.C) {
 	}{
 		{
 			message:   "no args shows help",
-			helpMatch: "usage: jujutest .*",
+			helpMatch: "Usage: jujutest .*",
 		}, {
 			message:     "usage prefix with help command",
 			args:        []string{"help"},
 			usagePrefix: "juju",
-			helpMatch:   "usage: juju jujutest .*",
+			helpMatch:   "Usage: juju jujutest .*",
 		}, {
 			message:     "usage prefix with help flag",
 			args:        []string{"--help"},
 			usagePrefix: "juju",
-			helpMatch:   "usage: juju jujutest .*",
+			helpMatch:   "Usage: juju jujutest .*",
 		}, {
 			message:   "help arg usage",
 			args:      []string{"blah", "--help"},
-			helpMatch: "usage: jujutest blah.*blah-doc.*",
+			helpMatch: "Usage: jujutest blah.*blah-doc.*",
 		}, {
 			message:     "usage prefix with help command",
 			args:        []string{"help", "blah"},
 			usagePrefix: "juju",
-			helpMatch:   "usage: juju jujutest blah .*",
+			helpMatch:   "Usage: juju jujutest blah .*",
 		}, {
 			message:     "usage prefix with help flag",
 			args:        []string{"blah", "--help"},
 			usagePrefix: "juju",
-			helpMatch:   "usage: juju jujutest blah .*",
+			helpMatch:   "Usage: juju jujutest blah .*",
 		}, {
 			message:  "too many args",
 			args:     []string{"help", "blah", "blah"},
@@ -108,7 +108,7 @@ func (s *HelpCommandSuite) TestMultipleSuperCommands(c *gc.C) {
 
 	ctx, err := cmdtesting.RunCommand(c, level1, "help", "level2", "level3", "blah")
 	c.Assert(err, jc.ErrorIsNil)
-	s.assertStdOutMatches(c, ctx, "usage: level1 level2 level3 blah.*blah-doc.*")
+	s.assertStdOutMatches(c, ctx, "Usage: level1 level2 level3 blah.*blah-doc.*")
 
 	_, err = cmdtesting.RunCommand(c, level1, "help", "level2", "missing", "blah")
 	c.Assert(err, gc.ErrorMatches, `subcommand "missing" not found`)
@@ -121,7 +121,7 @@ func (s *HelpCommandSuite) TestAlias(c *gc.C) {
 	code := cmd.Main(super, ctx, []string{"help", "alias"})
 	c.Assert(code, gc.Equals, 0)
 	stripped := strings.Replace(bufferString(ctx.Stdout), "\n", "", -1)
-	c.Assert(stripped, gc.Matches, "usage: super blah .*aliases: alias")
+	c.Assert(stripped, gc.Matches, "Usage: super blah .*Aliases: alias")
 }
 
 func (s *HelpCommandSuite) TestRegisterSuperAliasHelp(c *gc.C) {
@@ -155,7 +155,7 @@ func (s *HelpCommandSuite) TestRegisterSuperAliasHelp(c *gc.C) {
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(jc, ctx, test.args)
 		c.Check(code, gc.Equals, 0)
-		help := "usage: jujutest bar foo\npurpose: to be simple\n"
+		help := "Usage: jujutest bar foo\n\nSummary:\nto be simple\n"
 		c.Check(cmdtesting.Stdout(ctx), gc.Equals, help)
 	}
 }

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -372,7 +372,7 @@ func (s *SuperCommandSuite) TestSupercommandAliases(c *gc.C) {
 		code := cmd.Main(jc, ctx, []string{name, "--help"})
 		c.Assert(code, gc.Equals, 0)
 		stripped := strings.Replace(bufferString(ctx.Stdout), "\n", "", -1)
-		c.Assert(stripped, gc.Matches, ".*usage: juju jujutest jubar.*aliases: jubaz, jubing")
+		c.Assert(stripped, gc.Matches, ".*Usage: juju jujutest jubar.*Aliases: jubaz, jubing")
 	}
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -67,20 +67,25 @@ func (c *TestCommand) Run(ctx *cmd.Context) error {
 
 // minimalHelp and fullHelp are the expected help strings for a TestCommand
 // with Name "verb", with and without Minimal set.
-var minimalHelp = "usage: verb\n"
-var optionHelp = `usage: verb [options] <something>
-purpose: verb the juju
+var minimalHelp = "Usage: verb\n"
+var optionHelp = `Usage: verb [options] <something>
 
-options:
+Summary:
+verb the juju
+
+Options:
 --option (= "")
     option-doc
 `
-var fullHelp = `usage: verb [options] <something>
-purpose: verb the juju
+var fullHelp = `Usage: verb [options] <something>
 
-options:
+Summary:
+verb the juju
+
+Options:
 --option (= "")
     option-doc
 
+Details:
 verb-doc
 `


### PR DESCRIPTION
At the request of the docs team, update the formatting
of the help text to be more in line with help text for
other commands, and to not be allergic to capitalization.

https://bugs.launchpad.net/juju-core/+bug/1553272

(Review request: http://reviews.vapour.ws/r/4075/)