### PR TITLE
add stringmap type

### DIFF
--- a/stringmap.go
+++ b/stringmap.go
@@ -1,4 +1,4 @@
-// Copyright 2012, 2013 Canonical Ltd.
+// Copyright 2016 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENSE file for details.
 
 package cmd

--- a/stringmap.go
+++ b/stringmap.go
@@ -1,0 +1,45 @@
+// Copyright 2012, 2013 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENSE file for details.
+
+package cmd
+
+import (
+	"fmt"
+	"strings"
+)
+
+// StringMap is a type that deserializes a CLI string using gnuflag's Value
+// semantics.  It expects a name=value pair, and supports multiple copies of the
+// flag adding more pairs, though the names must be unique.
+type StringMap struct {
+	mapping *map[string]string
+}
+
+// Set implements gnuflag.Value's Set method.
+func (m StringMap) Set(s string) error {
+	if *m.mapping == nil {
+		*m.mapping = map[string]string{}
+	}
+	// make a copy so the following code is less ugly with dereferencing.
+	mapping := *m.mapping
+
+	vals := strings.SplitN(s, "=", 2)
+	if len(vals) != 2 {
+		return fmt.Errorf("badly formatted name value pair: " + s)
+	}
+	name, value := vals[0], vals[1]
+	if _, ok := mapping[name]; ok {
+		return fmt.Errorf("duplicate name specified: %q", name)
+	}
+	mapping[name] = value
+	return nil
+}
+
+// String implements gnuflag.Value's String method
+func (m StringMap) String() string {
+	pairs := make([]string, 0, len(*m.mapping))
+	for name, value := range *m.mapping {
+		pairs = append(pairs, name+"="+value)
+	}
+	return strings.Join(pairs, ";")
+}

--- a/stringmap_test.go
+++ b/stringmap_test.go
@@ -1,5 +1,5 @@
-// Copyright 2015 Canonical Ltd.
-// Licensed under the AGPLv3, see LICENCE file for details.
+// Copyright 2016 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
 
 package cmd
 

--- a/stringmap_test.go
+++ b/stringmap_test.go
@@ -1,0 +1,47 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package cmd
+
+import (
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+)
+
+var _ = gc.Suite(&StringMapSuite{})
+
+type StringMapSuite struct {
+	testing.IsolationSuite
+}
+
+func (StringMapSuite) TestStringMapNilOk(c *gc.C) {
+	// note that the map may start out nil
+	var values map[string]string
+	c.Assert(values, gc.IsNil)
+	sm := StringMap{&values}
+	err := sm.Set("foo=foovalue")
+	c.Assert(err, jc.ErrorIsNil)
+	err = sm.Set("bar=barvalue")
+	c.Assert(err, jc.ErrorIsNil)
+
+	// now the map is non-nil and filled
+	c.Assert(values, gc.DeepEquals, map[string]string{
+		"foo": "foovalue",
+		"bar": "barvalue",
+	})
+}
+
+func (StringMapSuite) TestStringMapBadVal(c *gc.C) {
+	sm := StringMap{&map[string]string{}}
+	err := sm.Set("foo")
+	c.Assert(err, gc.ErrorMatches, "badly formatted name value pair: foo")
+}
+
+func (StringMapSuite) TestStringMapDupVal(c *gc.C) {
+	sm := StringMap{&map[string]string{}}
+	err := sm.Set("bar=somevalue")
+	c.Assert(err, jc.ErrorIsNil)
+	err = sm.Set("bar=someothervalue")
+	c.Assert(err, gc.ErrorMatches, ".*duplicate.*bar.*")
+}


### PR DESCRIPTION
This adds a type that supported --flagname key1=value1 --flagname key2=value2 semantics, which is currently used by resources both in juju/juju and in the charmstore-client (thus why we want a common place for it). Plus, it's just a useful general thing to have.

(Review request: http://reviews.vapour.ws/r/4190/)