### PR TITLE
Trim cmd.Info.{Purpose|Doc} whitespace consistently

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -225,7 +225,7 @@ func (i *Info) Help(f *gnuflag.FlagSet) []byte {
 	}
 	fmt.Fprintf(buf, "\n")
 	if i.Purpose != "" {
-		fmt.Fprintf(buf, "\nSummary:\n%s\n", strings.TrimSpace((i.Purpose)))
+		fmt.Fprintf(buf, "\nSummary:\n%s\n", strings.TrimSpace(i.Purpose))
 	}
 	if hasOptions {
 		fmt.Fprintf(buf, "\nOptions:\n")

--- a/cmd.go
+++ b/cmd.go
@@ -225,7 +225,7 @@ func (i *Info) Help(f *gnuflag.FlagSet) []byte {
 	}
 	fmt.Fprintf(buf, "\n")
 	if i.Purpose != "" {
-		fmt.Fprintf(buf, "\nSummary:\n%s\n", i.Purpose)
+		fmt.Fprintf(buf, "\nSummary:\n%s\n", strings.TrimSpace((i.Purpose)))
 	}
 	if hasOptions {
 		fmt.Fprintf(buf, "\nOptions:\n")

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"launchpad.net/gnuflag"
+
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/cmd"
@@ -170,4 +172,38 @@ func (s *CmdSuite) TestIsErrSilent(c *gc.C) {
 	c.Assert(cmd.IsErrSilent(cmd.ErrSilent), gc.Equals, true)
 	c.Assert(cmd.IsErrSilent(cmd.NewRcPassthroughError(99)), gc.Equals, true)
 	c.Assert(cmd.IsErrSilent(fmt.Errorf("noisy")), gc.Equals, false)
+}
+
+func (s *CmdSuite) TestInfoHelp(c *gc.C) {
+	// Test that white space is trimmed consistently from cmd.Info.Purpose
+	// (Help Summary) and cmd.Info.Doc (Help Details)
+	option := "option"
+	fs := gnuflag.NewFlagSet("", gnuflag.ContinueOnError)
+	fs.StringVar(&option, "option", "", "option-doc")
+
+	table := []struct {
+		summary, details, want string
+	}{
+		{`
+			verb the juju`,
+			`
+			verb-doc`, fullHelp},
+		{`verb the juju`, `verb-doc`, fullHelp},
+		{`
+			
+			verb the juju`,
+			`
+			
+			verb-doc`, fullHelp},
+	}
+
+	for _, tv := range table {
+		i := cmd.Info{
+			Name:    "verb",
+			Args:    "<something>",
+			Purpose: tv.summary,
+			Doc:     tv.details,
+		}
+		c.Assert(string(i.Help(fs)), gc.Equals, tv.want)
+	}
 }

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -182,21 +182,24 @@ func (s *CmdSuite) TestInfoHelp(c *gc.C) {
 	fs.StringVar(&option, "option", "", "option-doc")
 
 	table := []struct {
-		summary, details, want string
+		summary, details string
 	}{
 		{`
 			verb the juju`,
 			`
-			verb-doc`, fullHelp},
-		{`verb the juju`, `verb-doc`, fullHelp},
+			verb-doc`},
+		{`verb the juju`, `verb-doc`},
 		{`
 			
 			verb the juju`,
 			`
 			
-			verb-doc`, fullHelp},
-	}
+			verb-doc`},
+		{`verb the juju    `, `verb-doc
 
+		 `},
+	}
+	want := fullHelp
 	for _, tv := range table {
 		i := cmd.Info{
 			Name:    "verb",
@@ -204,6 +207,7 @@ func (s *CmdSuite) TestInfoHelp(c *gc.C) {
 			Purpose: tv.summary,
 			Doc:     tv.details,
 		}
-		c.Assert(string(i.Help(fs)), gc.Equals, tv.want)
+		got := string(i.Help(fs))
+		c.Check(got, gc.Equals, want)
 	}
 }


### PR DESCRIPTION
New usage/help text may have  multi line "summaries"
(cmd.Info.Purpose). e.g.
https://bugs.launchpad.net/juju-core/+bug/1555248
https://bugs.launchpad.net/juju-core/+bug/1558078

cmd.Info.Help was trimming white space from "details" (cmd.Info.Doc) but
not cmd.Purpose. This requires multi line strings destined for summary
and details to be written differently in juju-core
(github.com/juju/juju) commands.

This PR trims whitespace consistently, so that help text may be written
consistently.

(Review request: http://reviews.vapour.ws/r/4341/)