### PR TITLE
Do not inline the SetLogLevel() call.

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -100,7 +100,8 @@ func (log *Log) Start(ctx *Context) error {
 		}
 	}
 	// Set the level on the root logger.
-	loggo.GetLogger("").SetLogLevel(level)
+	root := loggo.GetLogger("")
+	root.SetLogLevel(level)
 	// Override the logging config with specified logging config.
 	loggo.ConfigureLoggers(log.Config)
 	return nil


### PR DESCRIPTION
Since GetLogger() returns a value rather than a pointer, pointer methods on the returned Logger cannot be inlined.  This becomes a problem if any changes are made to Logger's methods relative to pointer receivers.  I plan on making such a change, so I'm fixing this here first.

(Review request: http://reviews.vapour.ws/r/4829/)