### PR TITLE
add HelpNotify to SuperCommand parameters

### DIFF
--- a/help.go
+++ b/help.go
@@ -105,6 +105,9 @@ See also: topics
 }
 
 func (c *helpCommand) Init(args []string) error {
+	if c.super.notifyHelp != nil {
+		c.super.notifyHelp(args)
+	}
 	logger.Tracef("helpCommand.Init: %#v", args)
 	if len(args) == 0 {
 		// If there is no help topic specified, print basic usage if it is

--- a/help_test.go
+++ b/help_test.go
@@ -159,3 +159,21 @@ func (s *HelpCommandSuite) TestRegisterSuperAliasHelp(c *gc.C) {
 		c.Check(cmdtesting.Stdout(ctx), gc.Equals, help)
 	}
 }
+
+func (s *HelpCommandSuite) TestNotifyHelp(c *gc.C) {
+	var called [][]string
+	super := cmd.NewSuperCommand(cmd.SuperCommandParams{
+		Name: "super",
+		NotifyHelp: func(args []string) {
+			called = append(called, args)
+		},
+	})
+	super.Register(&TestCommand{
+		Name: "blah",
+	})
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(super, ctx, []string{"help", "blah"})
+	c.Assert(code, gc.Equals, 0)
+
+	c.Assert(called, jc.DeepEquals, [][]string{{"blah"}})
+}

--- a/supercommand.go
+++ b/supercommand.go
@@ -49,6 +49,13 @@ type SuperCommandParams struct {
 	// is about to run a sub-command.
 	NotifyRun func(cmdName string)
 
+	// NotifyHelp is called just before help is printed, with the
+	// arguments received by the help command. This can be
+	// used, for example, to load command information for external
+	// "plugin" commands, so that their documentation will show up
+	// in the help output.
+	NotifyHelp func([]string)
+
 	Name            string
 	Purpose         string
 	Doc             string
@@ -77,6 +84,7 @@ func NewSuperCommand(params SuperCommandParams) *SuperCommand {
 		Aliases:             params.Aliases,
 		version:             params.Version,
 		notifyRun:           params.NotifyRun,
+		notifyHelp:          params.NotifyHelp,
 		userAliasesFilename: params.UserAliasesFilename,
 	}
 	command.init()
@@ -130,6 +138,7 @@ type SuperCommand struct {
 	noAlias             bool
 	missingCallback     MissingCallback
 	notifyRun           func(string)
+	notifyHelp          func([]string)
 }
 
 // IsSuperCommand implements Command.IsSuperCommand


### PR DESCRIPTION
This allows us to add plugin command help details on
demand so that they can look like first-class citizens
without requiring us to load them dynamically before
we know whether they're needed or not.

(Review request: http://reviews.vapour.ws/r/4904/)