### PR TITLE
Pass the writer into the formatter.

### DIFF
--- a/output_test.go
+++ b/output_test.go
@@ -50,8 +50,8 @@ var outputTests = map[string][]struct {
 	output string
 }{
 	"": {
-		{nil, ""},
-		{"", ""},
+		{nil, "\n"},
+		{"", "\n"},
 		{1, "1\n"},
 		{-1, "-1\n"},
 		{1.1, "1.1\n"},
@@ -65,8 +65,8 @@ var outputTests = map[string][]struct {
 		{map[interface{}]interface{}{"foo": "bar"}, "foo: bar\n"},
 	},
 	"smart": {
-		{nil, ""},
-		{"", ""},
+		{nil, "\n"},
+		{"", "\n"},
 		{1, "1\n"},
 		{-1, "-1\n"},
 		{1.1, "1.1\n"},
@@ -97,7 +97,7 @@ var outputTests = map[string][]struct {
 		{defaultValue, `{"Juju":1,"Puppet":false}` + "\n"},
 	},
 	"yaml": {
-		{nil, ""},
+		{nil, "\n"},
 		{"", `""` + "\n"},
 		{1, "1\n"},
 		{-1, "-1\n"},


### PR DESCRIPTION
In order for Juju commands to be able to have colors in the tabulated output, we need to pass the writer from the command context through to the formatter.

This branch also modifies the yaml formatter to be more standard, and not trim things "just because".

(Review request: http://reviews.vapour.ws/r/5455/)