### PR TITLE
Don't add newlines for empty smart output.

### DIFF
--- a/output_test.go
+++ b/output_test.go
@@ -50,8 +50,8 @@ var outputTests = map[string][]struct {
 	output string
 }{
 	"": {
-		{nil, "\n"},
-		{"", "\n"},
+		{nil, ""},
+		{"", ""},
 		{1, "1\n"},
 		{-1, "-1\n"},
 		{1.1, "1.1\n"},
@@ -65,8 +65,8 @@ var outputTests = map[string][]struct {
 		{map[interface{}]interface{}{"foo": "bar"}, "foo: bar\n"},
 	},
 	"smart": {
-		{nil, "\n"},
-		{"", "\n"},
+		{nil, ""},
+		{"", ""},
 		{1, "1\n"},
 		{-1, "-1\n"},
 		{1.1, "1.1\n"},
@@ -97,7 +97,7 @@ var outputTests = map[string][]struct {
 		{defaultValue, `{"Juju":1,"Puppet":false}` + "\n"},
 	},
 	"yaml": {
-		{nil, "\n"},
+		{nil, ""},
 		{"", `""` + "\n"},
 		{1, "1\n"},
 		{-1, "-1\n"},


### PR DESCRIPTION
This branch takes the output of smart and yaml back to what it was before the branch that passed the writer into the formatters. Since charms that use bash for scripting have certain expectations on the output, best to put it back where it was.

To keep with current behaviour of other formatters, non-default (i.e. not "smart", "yaml" or "json") get an extra newline at the end.

(Review request: http://reviews.vapour.ws/r/5511/)