### PR TITLE
cmd: add Output.WriteFormatter method

### DIFF
--- a/output_test.go
+++ b/output_test.go
@@ -36,7 +36,15 @@ func (c *OutputCommand) Init(args []string) error {
 }
 
 func (c *OutputCommand) Run(ctx *cmd.Context) error {
+	if value, ok := c.value.(overrideFormatter); ok {
+		return c.out.WriteFormatter(ctx, value.formatter, value.value)
+	}
 	return c.out.Write(ctx, c.value)
+}
+
+type overrideFormatter struct {
+	formatter cmd.Formatter
+	value     interface{}
 }
 
 // use a struct to control field ordering.
@@ -64,6 +72,7 @@ var outputTests = map[string][]struct {
 		{[]string{}, ""},
 		{[]string{"blam", "dink"}, "blam\ndink\n"},
 		{map[interface{}]interface{}{"foo": "bar"}, "foo: bar\n"},
+		{overrideFormatter{cmd.FormatSmart, "abc\ndef"}, "abc\ndef\n"},
 	},
 	"smart": {
 		{nil, ""},
@@ -81,6 +90,7 @@ var outputTests = map[string][]struct {
 		{[]string{"blam", "dink"}, "blam\ndink\n"},
 		{[2]string{"blam", "dink"}, "blam\ndink\n"},
 		{map[interface{}]interface{}{"foo": "bar"}, "foo: bar\n"},
+		{overrideFormatter{cmd.FormatSmart, "abc\ndef"}, "abc\ndef\n"},
 	},
 	"json": {
 		{nil, "null\n"},
@@ -97,6 +107,7 @@ var outputTests = map[string][]struct {
 		{[]string{}, `[]` + "\n"},
 		{[]string{"blam", "dink"}, `["blam","dink"]` + "\n"},
 		{defaultValue, `{"Juju":1,"Puppet":false}` + "\n"},
+		{overrideFormatter{cmd.FormatSmart, "abc\ndef"}, "abc\ndef\n"},
 	},
 	"yaml": {
 		{nil, ""},
@@ -113,6 +124,7 @@ var outputTests = map[string][]struct {
 		{[]string{}, "[]\n"},
 		{[]string{"blam", "dink"}, "- blam\n- dink\n"},
 		{defaultValue, "juju: 1\npuppet: false\n"},
+		{overrideFormatter{cmd.FormatSmart, "abc\ndef"}, "abc\ndef\n"},
 	},
 }
 


### PR DESCRIPTION
Add a WriteFormatter method to Output, so that
commands can override the formatter selected
by the user. This will be used for special
cases such as printing a single key in a config
map.