### PR TITLE
Use error logger to log command initialization and command run ...

### DIFF
--- a/cmd_test.go
+++ b/cmd_test.go
@@ -15,9 +15,12 @@ import (
 
 	"github.com/juju/cmd"
 	"github.com/juju/cmd/cmdtesting"
+	"github.com/juju/testing"
 )
 
-type CmdSuite struct{}
+type CmdSuite struct {
+	testing.LoggingCleanupSuite
+}
 
 var _ = gc.Suite(&CmdSuite{})
 
@@ -80,7 +83,7 @@ func (s *CmdSuite) TestMainInitError(c *gc.C) {
 		result := cmd.Main(t.c, ctx, []string{"--unknown"})
 		c.Assert(result, gc.Equals, 2)
 		c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
-		expected := "error: flag provided but not defined: --unknown\n"
+		expected := "ERROR flag provided but not defined: --unknown\n"
 		c.Assert(bufferString(ctx.Stderr), gc.Equals, expected)
 	}
 }
@@ -90,7 +93,7 @@ func (s *CmdSuite) TestMainRunError(c *gc.C) {
 	result := cmd.Main(&TestCommand{Name: "verb"}, ctx, []string{"--option", "error"})
 	c.Assert(result, gc.Equals, 1)
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "")
-	c.Assert(bufferString(ctx.Stderr), gc.Equals, "error: BAM!\n")
+	c.Assert(bufferString(ctx.Stderr), gc.Equals, "ERROR BAM!\n")
 }
 
 func (s *CmdSuite) TestMainRunSilentError(c *gc.C) {

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -238,14 +238,14 @@ func (s *SuperCommandSuite) TestVersionNotProvided(c *gc.C) {
 	// juju version
 	baselineCode := cmd.Main(jc, ctx, []string{"version"})
 	c.Check(baselineCode, gc.Not(gc.Equals), 0)
-	c.Assert(stderr.String(), gc.Equals, "error: unrecognized command: jujutest version\n")
+	c.Assert(stderr.String(), gc.Equals, "ERROR unrecognized command: jujutest version\n")
 	stderr.Reset()
 	stdout.Reset()
 
 	// juju --version
 	code := cmd.Main(jc, ctx, []string{"--version"})
 	c.Check(code, gc.Equals, baselineCode)
-	c.Assert(stderr.String(), gc.Equals, "error: flag provided but not defined: --version\n")
+	c.Assert(stderr.String(), gc.Equals, "ERROR flag provided but not defined: --version\n")
 }
 
 func (s *SuperCommandSuite) TestLogging(c *gc.C) {
@@ -285,7 +285,7 @@ func (s *SuperCommandSuite) TestNotifyRun(c *gc.C) {
 		sc.Register(&TestCommand{Name: "blah"})
 		ctx := cmdtesting.Context(c)
 		code := cmd.Main(sc, ctx, []string{"blah", "--option", "error"})
-		c.Assert(bufferString(ctx.Stderr), gc.Matches, "")
+		c.Assert(bufferString(ctx.Stderr), gc.Matches, "ERROR BAM!\n")
 		c.Assert(code, gc.Equals, 1)
 		c.Assert(notifyName, gc.Equals, test.expectName)
 	}
@@ -451,7 +451,7 @@ func (s *SuperCommandSuite) TestRegisterAlias(c *gc.C) {
 			stderr: "WARNING: \"bar\" is deprecated, please use \"test\"\n",
 		}, {
 			name:   "baz",
-			stderr: "error: unrecognized command: jujutest baz\n",
+			stderr: "ERROR unrecognized command: jujutest baz\n",
 			code:   2,
 		},
 	} {
@@ -516,7 +516,7 @@ func (s *SuperCommandSuite) TestRegisterSuperAlias(c *gc.C) {
 			stderr: "WARNING: \"bar-dep\" is deprecated, please use \"bar foo\"\n",
 		}, {
 			args:   []string{"bar-ob", "arg"},
-			stderr: "error: unrecognized command: jujutest bar-ob\n",
+			stderr: "ERROR unrecognized command: jujutest bar-ob\n",
 			code:   2,
 		},
 	} {
@@ -576,11 +576,11 @@ func (s *SuperCommandSuite) TestRegisterDeprecated(c *gc.C) {
 			stderr: "WARNING: \"test-dep-alias\" is deprecated, please use \"test-dep-new\"\n",
 		}, {
 			args:   []string{"test-ob", "arg"},
-			stderr: "error: unrecognized command: jujutest test-ob\n",
+			stderr: "ERROR unrecognized command: jujutest test-ob\n",
 			code:   2,
 		}, {
 			args:   []string{"test-ob-alias", "arg"},
-			stderr: "error: unrecognized command: jujutest test-ob-alias\n",
+			stderr: "ERROR unrecognized command: jujutest test-ob-alias\n",
 			code:   2,
 		},
 	} {

--- a/version_test.go
+++ b/version_test.go
@@ -20,6 +20,7 @@ func (s *VersionSuite) TestVersion(c *gc.C) {
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}
+
 	const version = "999.888.777"
 	code := Main(newVersionCommand(version), ctx, nil)
 	c.Check(code, gc.Equals, 0)
@@ -33,10 +34,11 @@ func (s *VersionSuite) TestVersionExtraArgs(c *gc.C) {
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}
+
 	code := Main(newVersionCommand("xxx"), ctx, []string{"foo"})
 	c.Check(code, gc.Equals, 2)
 	c.Assert(stdout.String(), gc.Equals, "")
-	c.Assert(stderr.String(), gc.Matches, "error: unrecognized args.*\n")
+	c.Assert(stderr.String(), gc.Matches, "ERROR unrecognized args.*\n")
 }
 
 func (s *VersionSuite) TestVersionJson(c *gc.C) {
@@ -45,6 +47,7 @@ func (s *VersionSuite) TestVersionJson(c *gc.C) {
 		Stdout: &stdout,
 		Stderr: &stderr,
 	}
+
 	const version = "999.888.777"
 	code := Main(newVersionCommand(version), ctx, []string{"--format", "json"})
 	c.Check(code, gc.Equals, 0)


### PR DESCRIPTION
errors so that error messages are printed more consistently.

- The logger is global and thus test setups configure the default log writer to hold a given test function's test output buffer. 