### PR TITLE
Write to Stderr directly for error output.

### DIFF
--- a/cmdtesting/package_test.go
+++ b/cmdtesting/package_test.go
@@ -1,0 +1,14 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENSE file for details.
+
+package cmdtesting_test
+
+import (
+	"testing"
+
+	gc "gopkg.in/check.v1"
+)
+
+func TestPackage(t *testing.T) {
+	gc.TestingT(t)
+}

--- a/cmdtesting/prompt.go
+++ b/cmdtesting/prompt.go
@@ -1,0 +1,220 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENSE file for details.
+
+package cmdtesting
+
+import (
+	"io"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/loggo"
+	gc "gopkg.in/check.v1"
+)
+
+var logger = loggo.GetLogger("juju.cmd.testing")
+
+// NewSeqPrompter returns a prompter that can be used to check a sequence of
+// IO interactions. Expected input from the user is marked with the
+// given user input marker (for example a distinctive unicode character
+// that will not occur in the rest of the text) and runs to the end of a
+// line.
+//
+// All output text in between user input is treated as regular expressions.
+//
+// As a special case, if an input marker is followed only by a single input
+// marker on that line, the checker will cause io.EOF to be returned for
+// that prompt.
+//
+// The returned SeqPrompter wraps a Prompter and checks that each
+// read and write corresponds to the expected action in the sequence.
+//
+// After all interaction is done, CheckDone or AssertDone should be called to
+// check that no more interactions are expected.
+//
+// Any failures will result in the test failing.
+//
+// For example given the prompter created with:
+//
+//		checker := NewSeqPrompter(c, "»",  `What is your name: »Bob
+//	And your age: »148
+//	You're .* old, Bob!
+//	`)
+//
+// The following code will pass the checker:
+//
+//	fmt.Fprintf(checker, "What is your name: ")
+//	buf := make([]byte, 100)
+//	n, _ := checker.Read(buf)
+//	name := strings.TrimSpace(string(buf[0:n]))
+//	fmt.Fprintf(checker, "And your age: ")
+//	n, _ = checker.Read(buf)
+//	age, err := strconv.Atoi(strings.TrimSpace(string(buf[0:n])))
+//	c.Assert(err, gc.IsNil)
+//	if age > 90 {
+//		fmt.Fprintf(checker, "You're very old, %s!\n", name)
+//	}
+//	checker.CheckDone()
+func NewSeqPrompter(c *gc.C, userInputMarker, text string) *SeqPrompter {
+	p := &SeqPrompter{
+		c: c,
+	}
+	for {
+		i := strings.Index(text, userInputMarker)
+		if i == -1 {
+			p.finalText = text
+			break
+		}
+		prompt := text[0:i]
+		text = text[i+len(userInputMarker):]
+		endLine := strings.Index(text, "\n")
+		if endLine == -1 {
+			c.Errorf("no newline found after expected input %q", text)
+		}
+		reply := text[0 : endLine+1]
+		if reply[0:len(reply)-1] == userInputMarker {
+			// EOF line.
+			reply = ""
+		}
+		text = text[endLine+1:]
+		if prompt == "" && len(p.ios) > 0 {
+			// Combine multiple contiguous inputs together.
+			p.ios[len(p.ios)-1].reply += reply
+		} else {
+			p.ios = append(p.ios, ioInteraction{
+				prompt: prompt,
+				reply:  reply,
+			})
+		}
+	}
+	p.Prompter = NewPrompter(p.prompt)
+	return p
+}
+
+type SeqPrompter struct {
+	*Prompter
+	c         *gc.C
+	ios       []ioInteraction
+	finalText string
+	failed    bool
+}
+
+type ioInteraction struct {
+	prompt string
+	reply  string
+}
+
+func (p *SeqPrompter) prompt(text string) (string, error) {
+	if p.failed {
+		return "", errors.New("prompter failed")
+	}
+	if len(p.ios) == 0 {
+		p.c.Errorf("unexpected prompt %q; expected none", text)
+		return "", errors.New("unexpected prompt")
+	}
+	if !p.c.Check(text, gc.Matches, p.ios[0].prompt) {
+		p.failed = true
+		return "", errors.Errorf("unexpected prompt %q; expected %q", text, p.ios[0].prompt)
+	}
+	reply := p.ios[0].reply
+	logger.Infof("prompt %q -> %q", text, reply)
+	p.ios = p.ios[1:]
+	return reply, nil
+}
+
+// CheckDone asserts that all the expected prompts
+// have been printed and all the replies read, and
+// reports whether the check succeeded.
+func (p *SeqPrompter) CheckDone() bool {
+	if p.failed {
+		// No point in doing the details checks if
+		// a prompt failed earlier - it just makes
+		// the resulting test failure noisy.
+		p.c.Errorf("prompter has failed")
+		return false
+	}
+	r := p.c.Check(p.ios, gc.HasLen, 0, gc.Commentf("unused prompts"))
+	r = p.c.Check(p.HasUnread(), gc.Equals, false, gc.Commentf("some input was not read")) && r
+	r = p.c.Check(p.Tail(), gc.Matches, p.finalText, gc.Commentf("final text mismatch")) && r
+	return r
+}
+
+// AssertDone is like CheckDone but aborts the test if
+// the check fails.
+func (p *SeqPrompter) AssertDone() {
+	if !p.CheckDone() {
+		p.c.FailNow()
+	}
+}
+
+// NewPrompter returns an io.ReadWriter implementation that calls the
+// given function every time Read is called after some text has been
+// written or if all the previously returned text has been read. The
+// function's argument contains all the text printed since the last
+// input. The function should return the text that the user is expected
+// to type, or an error to return from Read. If it returns an empty string,
+// and no error, it will return io.EOF instead.
+func NewPrompter(prompt func(string) (string, error)) *Prompter {
+	return &Prompter{
+		prompt: prompt,
+	}
+}
+
+// Prompter is designed to be used in a cmd.Context to
+// check interactive request-response sequences
+// using stdin and stdout.
+type Prompter struct {
+	prompt func(string) (string, error)
+
+	written      []byte
+	allWritten   []byte
+	pending      []byte
+	pendingError error
+}
+
+// Tail returns all the text written since the last prompt.
+func (p *Prompter) Tail() string {
+	return string(p.written)
+}
+
+// HasUnread reports whether any input
+// from the last prompt remains unread.
+func (p *Prompter) HasUnread() bool {
+	return len(p.pending) != 0
+}
+
+// Read implements io.Reader.
+func (p *Prompter) Read(buf []byte) (int, error) {
+	if len(p.pending) == 0 && p.pendingError == nil {
+		s, err := p.prompt(string(p.written))
+		if s == "" && err == nil {
+			err = io.EOF
+		}
+		p.written = nil
+		p.pending = []byte(s)
+		p.pendingError = err
+	}
+	if len(p.pending) > 0 {
+		n := copy(buf, p.pending)
+		p.pending = p.pending[n:]
+		return n, nil
+	}
+	if err := p.pendingError; err != nil {
+		p.pendingError = nil
+		return 0, err
+	}
+	panic("unreachable")
+}
+
+// String returns all the text that has been written to
+// the prompter since it was created.
+func (p *Prompter) String() string {
+	return string(p.allWritten)
+}
+
+// Write implements io.Writer.
+func (p *Prompter) Write(buf []byte) (int, error) {
+	p.written = append(p.written, buf...)
+	p.allWritten = append(p.allWritten, buf...)
+	return len(buf), nil
+}

--- a/cmdtesting/prompt_test.go
+++ b/cmdtesting/prompt_test.go
@@ -1,0 +1,136 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENSE file for details.
+
+package cmdtesting_test
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/juju/errors"
+	"github.com/juju/testing"
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/cmd/cmdtesting"
+)
+
+type prompterSuite struct {
+	testing.IsolationSuite
+}
+
+var _ = gc.Suite(&prompterSuite{})
+
+func (*prompterSuite) TestPrompter(c *gc.C) {
+	noPrompt := func(p string) (string, error) {
+		c.Fatalf("unpexected prompt (text %q)", p)
+		panic("unreachable")
+	}
+	promptFn := noPrompt
+	p := cmdtesting.NewPrompter(func(p string) (string, error) {
+		return promptFn(p)
+	})
+
+	promptText := "hello: "
+	promptReply := "reply\n"
+
+	fmt.Fprint(p, promptText)
+	promptFn = func(p string) (string, error) {
+		c.Assert(p, gc.Equals, promptText)
+		return promptReply, nil
+	}
+	c.Assert(readStr(c, p, 20), gc.Equals, promptReply)
+
+	promptText = "some text\ngoodbye: "
+	promptReply = "again\n"
+	fmt.Fprint(p, promptText[0:10])
+	fmt.Fprint(p, promptText[10:])
+
+	c.Assert(readStr(c, p, 3), gc.Equals, promptReply[0:3])
+	c.Assert(readStr(c, p, 20), gc.Equals, promptReply[3:])
+
+	fmt.Fprint(p, "final text\n")
+
+	c.Assert(p.Tail(), gc.Equals, "final text\n")
+	c.Assert(p.HasUnread(), gc.Equals, false)
+}
+
+func (*prompterSuite) TestUnreadInput(c *gc.C) {
+	p := cmdtesting.NewPrompter(func(s string) (string, error) {
+		return "hello world", nil
+	})
+	c.Assert(readStr(c, p, 3), gc.Equals, "hel")
+
+	c.Assert(p.HasUnread(), gc.Equals, true)
+}
+
+func (*prompterSuite) TestError(c *gc.C) {
+	expectErr := errors.New("something")
+	p := cmdtesting.NewPrompter(func(s string) (string, error) {
+		return "", expectErr
+	})
+	buf := make([]byte, 3)
+	n, err := p.Read(buf)
+	c.Assert(n, gc.Equals, 0)
+	c.Assert(err, gc.Equals, expectErr)
+}
+
+func (*prompterSuite) TestSeqPrompter(c *gc.C) {
+	p := cmdtesting.NewSeqPrompter(c, "»", `
+hello: »reply
+some text
+goodbye: »again
+final
+`[1:])
+	fmt.Fprint(p, "hello: ")
+	c.Assert(readStr(c, p, 1), gc.Equals, "r")
+	c.Assert(readStr(c, p, 20), gc.Equals, "eply\n")
+	fmt.Fprint(p, "some text\n")
+	fmt.Fprint(p, "goodbye: ")
+	c.Assert(readStr(c, p, 20), gc.Equals, "again\n")
+	fmt.Fprint(p, "final\n")
+	p.AssertDone()
+}
+
+func (*prompterSuite) TestSeqPrompterEOF(c *gc.C) {
+	p := cmdtesting.NewSeqPrompter(c, "»", `
+hello: »»
+final
+`[1:])
+	fmt.Fprint(p, "hello: ")
+	n, err := p.Read(make([]byte, 10))
+	c.Assert(n, gc.Equals, 0)
+	c.Assert(err, gc.Equals, io.EOF)
+	fmt.Fprint(p, "final\n")
+	p.AssertDone()
+}
+
+func (*prompterSuite) TestNewIOChecker(c *gc.C) {
+	checker := cmdtesting.NewSeqPrompter(c, "»", `What is your name: »Bob
+»more
+And your age: »148
+You're .* old, Bob
+more!
+`)
+	fmt.Fprintf(checker, "What is your name: ")
+	buf := make([]byte, 100)
+	n, _ := checker.Read(buf)
+	name := strings.TrimSpace(string(buf[0:n]))
+	fmt.Fprintf(checker, "And your age: ")
+	n, _ = checker.Read(buf)
+	age, err := strconv.Atoi(strings.TrimSpace(string(buf[0:n])))
+	c.Assert(err, gc.IsNil)
+	if age > 90 {
+		fmt.Fprintf(checker, "You're very old, %s!\n", name)
+	}
+	checker.CheckDone()
+}
+
+func readStr(c *gc.C, r io.Reader, nb int) string {
+	buf := make([]byte, nb)
+	n, err := r.Read(buf)
+	c.Assert(err, jc.ErrorIsNil)
+	return string(buf[0:n])
+}

--- a/export_test.go
+++ b/export_test.go
@@ -1,0 +1,8 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENSE file for details.
+
+package cmd
+
+func NewVersionCommand(version string) Command {
+	return newVersionCommand(version)
+}

--- a/supercommand.go
+++ b/supercommand.go
@@ -455,8 +455,8 @@ func (c *SuperCommand) Run(ctx *Context) error {
 	}
 	err := c.action.command.Run(ctx)
 	if err != nil && !IsErrSilent(err) {
-		logger.Errorf("%v", err)
-		logger.Debugf("(error details: %v)", errors.Details(err))
+		WriteError(ctx.Stderr, err)
+		logger.Debugf("error stack: \n%v", errors.ErrorStack(err))
 		// Now that this has been logged, don't log again in cmd.Main.
 		if !IsRcPassthroughError(err) {
 			err = ErrSilent

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -258,7 +258,7 @@ func (s *SuperCommandSuite) TestLogging(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(sc, ctx, []string{"blah", "--option", "error", "--debug"})
 	c.Assert(code, gc.Equals, 1)
-	c.Assert(bufferString(ctx.Stderr), gc.Matches, `^.* ERROR .* BAM!\n.* DEBUG .* \(error details.*\).*\n`)
+	c.Assert(bufferString(ctx.Stderr), gc.Matches, `(?m)ERROR BAM!\n.* DEBUG .* error stack: \n.*`)
 }
 
 func (s *SuperCommandSuite) TestNotifyRun(c *gc.C) {

--- a/version_test.go
+++ b/version_test.go
@@ -1,56 +1,48 @@
 // Copyright 2012, 2013 Canonical Ltd.
 // Licensed under the LGPLv3, see LICENSE file for details.
 
-package cmd
+package cmd_test
 
 import (
-	"bytes"
 	"fmt"
 
+	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
+
+	"github.com/juju/cmd"
+	"github.com/juju/cmd/cmdtesting"
 )
 
-type VersionSuite struct{}
+type VersionSuite struct {
+	testing.LoggingSuite
+}
 
 var _ = gc.Suite(&VersionSuite{})
 
 func (s *VersionSuite) TestVersion(c *gc.C) {
-	var stdout, stderr bytes.Buffer
-	ctx := &Context{
-		Stdout: &stdout,
-		Stderr: &stderr,
-	}
-
 	const version = "999.888.777"
-	code := Main(newVersionCommand(version), ctx, nil)
+
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(cmd.NewVersionCommand(version), ctx, nil)
 	c.Check(code, gc.Equals, 0)
-	c.Assert(stderr.String(), gc.Equals, "")
-	c.Assert(stdout.String(), gc.Equals, version+"\n")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, version+"\n")
 }
 
 func (s *VersionSuite) TestVersionExtraArgs(c *gc.C) {
-	var stdout, stderr bytes.Buffer
-	ctx := &Context{
-		Stdout: &stdout,
-		Stderr: &stderr,
-	}
-
-	code := Main(newVersionCommand("xxx"), ctx, []string{"foo"})
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(cmd.NewVersionCommand("xxx"), ctx, []string{"foo"})
 	c.Check(code, gc.Equals, 2)
-	c.Assert(stdout.String(), gc.Equals, "")
-	c.Assert(stderr.String(), gc.Matches, "ERROR unrecognized args.*\n")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, "ERROR unrecognized args.*\n")
 }
 
 func (s *VersionSuite) TestVersionJson(c *gc.C) {
-	var stdout, stderr bytes.Buffer
-	ctx := &Context{
-		Stdout: &stdout,
-		Stderr: &stderr,
-	}
-
 	const version = "999.888.777"
-	code := Main(newVersionCommand(version), ctx, []string{"--format", "json"})
+
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(cmd.NewVersionCommand(version), ctx, []string{"--format", "json"})
 	c.Check(code, gc.Equals, 0)
-	c.Assert(stderr.String(), gc.Equals, "")
-	c.Assert(stdout.String(), gc.Equals, fmt.Sprintf("%q\n", version))
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, fmt.Sprintf("%q\n", version))
 }


### PR DESCRIPTION
Using the logger for error output was a bad call.

This branch also brings in the non-juju specific extra methods used for testing commands.