### PR TITLE
expose Quiet method on Context

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -117,6 +117,13 @@ type Context struct {
 	verbose bool
 }
 
+// Quiet reports whether the command is in "quiet" mode. When
+// this is true, informational output should be suppressed (logger
+// messages can be used instead).
+func (ctx *Context) Quiet() bool {
+	return ctx.quiet
+}
+
 func (ctx *Context) write(format string, params ...interface{}) {
 	output := fmt.Sprintf(format, params...)
 	if !strings.HasSuffix(output, "\n") {


### PR DESCRIPTION
This allows commands that print informational messages directly
to ctxt.Stderr to decide to be quiet instead.