### PR TITLE
Allow to customise what command flags are known as.

### DIFF
--- a/cmdtesting/cmd.go
+++ b/cmdtesting/cmd.go
@@ -105,7 +105,13 @@ func HelpText(command cmd.Command, name string) string {
 	buff := &bytes.Buffer{}
 	info := command.Info()
 	info.Name = name
-	f := gnuflag.NewFlagSet(info.Name, gnuflag.ContinueOnError)
+	flagsAKA := info.FlagKnownAs
+	if flagsAKA == "" {
+		// For backward compatibility, the default is flags.
+		flagsAKA = "flag"
+	}
+
+	f := gnuflag.NewFlagSetWithFlagKnownAs(info.Name, gnuflag.ContinueOnError, flagsAKA)
 	command.SetFlags(f)
 	buff.Write(info.Help(f))
 	return buff.String()

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -246,6 +246,14 @@ func (s *SuperCommandSuite) TestVersionNotProvided(c *gc.C) {
 	code := cmd.Main(jc, ctx, []string{"--version"})
 	c.Check(code, gc.Equals, baselineCode)
 	c.Assert(stderr.String(), gc.Equals, "ERROR flag provided but not defined: --version\n")
+	stderr.Reset()
+	stdout.Reset()
+
+	// juju -version where flags are known as options
+	jc.FlagKnownAs = "option"
+	code = cmd.Main(jc, ctx, []string{"--version"})
+	c.Check(code, gc.Equals, baselineCode)
+	c.Assert(stderr.String(), gc.Equals, "ERROR option provided but not defined: --version\n")
 }
 
 func (s *SuperCommandSuite) TestLogging(c *gc.C) {

--- a/util_test.go
+++ b/util_test.go
@@ -25,19 +25,24 @@ type TestCommand struct {
 	Option  string
 	Minimal bool
 	Aliases []string
+	FlagAKA string
 }
 
 func (c *TestCommand) Info() *cmd.Info {
 	if c.Minimal {
 		return &cmd.Info{Name: c.Name}
 	}
-	return &cmd.Info{
+	i := &cmd.Info{
 		Name:    c.Name,
 		Args:    "<something>",
 		Purpose: c.Name + " the juju",
 		Doc:     c.Name + "-doc",
 		Aliases: c.Aliases,
 	}
+	if c.FlagAKA != "" {
+		i.FlagKnownAs = c.FlagAKA
+	}
+	return i
 }
 
 func (c *TestCommand) SetFlags(f *gnuflag.FlagSet) {
@@ -77,12 +82,12 @@ Options:
 --option (= "")
     option-doc
 `
-var fullHelp = `Usage: verb [options] <something>
+var fullHelp = `Usage: verb [%vs] <something>
 
 Summary:
 verb the juju
 
-Options:
+%vs:
 --option (= "")
     option-doc
 


### PR DESCRIPTION
For example, most common Juju preference is 'option'.

This will allow Juju to ensure that flags and options are named consistently. This is an intermediate step en route to solution for lp# 1637821.