### PR TITLE
Missed super command internal flag set and tests.

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -313,17 +313,19 @@ func handleCommandError(c Command, ctx *Context, err error, f *gnuflag.FlagSet) 
 	}
 }
 
+func FlagAlias(c Command, akaDefault string) string {
+	flagsAKA := c.Info().FlagKnownAs
+	if flagsAKA == "" {
+		return akaDefault
+	}
+	return flagsAKA
+}
+
 // Main runs the given Command in the supplied Context with the given
 // arguments, which should not include the command name. It returns a code
 // suitable for passing to os.Exit.
 func Main(c Command, ctx *Context, args []string) int {
-	flagsAKA := c.Info().FlagKnownAs
-	if flagsAKA == "" {
-		// For backward compatibility, the default is 'flags'.
-		flagsAKA = "flag"
-	}
-
-	f := gnuflag.NewFlagSetWithFlagKnownAs(c.Info().Name, gnuflag.ContinueOnError, flagsAKA)
+	f := gnuflag.NewFlagSetWithFlagKnownAs(c.Info().Name, gnuflag.ContinueOnError, FlagAlias(c, "flag"))
 	f.SetOutput(ioutil.Discard)
 	c.SetFlags(f)
 	if rc, done := handleCommandError(c, ctx, f.Parse(c.AllowInterspersedFlags(), args), f); done {

--- a/cmdtesting/cmd.go
+++ b/cmdtesting/cmd.go
@@ -24,7 +24,8 @@ func NewFlagSet() *gnuflag.FlagSet {
 // InitCommand will create a new flag set, and call the Command's SetFlags and
 // Init methods with the appropriate args.
 func InitCommand(c cmd.Command, args []string) error {
-	f := NewFlagSet()
+	f := gnuflag.NewFlagSetWithFlagKnownAs(c.Info().Name, gnuflag.ContinueOnError, cmd.FlagAlias(c, "flag"))
+	f.SetOutput(ioutil.Discard)
 	c.SetFlags(f)
 	if err := f.Parse(c.AllowInterspersedFlags(), args); err != nil {
 		return err
@@ -105,13 +106,7 @@ func HelpText(command cmd.Command, name string) string {
 	buff := &bytes.Buffer{}
 	info := command.Info()
 	info.Name = name
-	flagsAKA := info.FlagKnownAs
-	if flagsAKA == "" {
-		// For backward compatibility, the default is flags.
-		flagsAKA = "flag"
-	}
-
-	f := gnuflag.NewFlagSetWithFlagKnownAs(info.Name, gnuflag.ContinueOnError, flagsAKA)
+	f := gnuflag.NewFlagSetWithFlagKnownAs(info.Name, gnuflag.ContinueOnError, cmd.FlagAlias(command, "flag"))
 	command.SetFlags(f)
 	buff.Write(info.Help(f))
 	return buff.String()

--- a/help.go
+++ b/help.go
@@ -172,12 +172,18 @@ func (c *helpCommand) getCommandHelp(super *SuperCommand, command Command, alias
 		info.Name = fmt.Sprintf("%s %s", super.usagePrefix, info.Name)
 	}
 
-	flagsAKA := info.FlagKnownAs
+	flagsAKA := FlagAlias(command, "")
+	if flagsAKA == "" {
+		flagsAKA = FlagAlias(super, "")
+	}
 	if flagsAKA == "" {
 		flagsAKA = super.FlagKnownAs
 	}
 	if flagsAKA == "" {
-		flagsAKA = super.Info().FlagKnownAs
+		flagsAKA = FlagAlias(c, "")
+	}
+	if flagsAKA == "" {
+		flagsAKA = FlagAlias(c.super, "")
 	}
 	if flagsAKA == "" {
 		flagsAKA = c.super.FlagKnownAs

--- a/supercommand.go
+++ b/supercommand.go
@@ -340,6 +340,7 @@ func (c *SuperCommand) Info() *Info {
 	if c.action.command != nil {
 		info := *c.action.command.Info()
 		info.Name = fmt.Sprintf("%s %s", c.Name, info.Name)
+		info.FlagKnownAs = c.FlagKnownAs
 		return &info
 	}
 	docParts := []string{}
@@ -378,7 +379,7 @@ func (c *SuperCommand) SetCommonFlags(f *gnuflag.FlagSet) {
 	// The Purpose attribute will be printed (if defined), allowing
 	// plugins to provide a sensible line of text for 'juju help plugins'.
 	f.BoolVar(&c.showDescription, "description", false, "Show short description of plugin, if any")
-	c.commonflags = gnuflag.NewFlagSet(c.Info().Name, gnuflag.ContinueOnError)
+	c.commonflags = gnuflag.NewFlagSetWithFlagKnownAs(c.Info().Name, gnuflag.ContinueOnError, FlagAlias(c, "flag"))
 	c.commonflags.SetOutput(ioutil.Discard)
 	f.VisitAll(func(flag *gnuflag.Flag) {
 		c.commonflags.Var(flag.Value, flag.Name, flag.Usage)
@@ -443,7 +444,7 @@ func (c *SuperCommand) Init(args []string) error {
 	args = args[1:]
 	subcmd := c.action.command
 	if subcmd.IsSuperCommand() {
-		f := gnuflag.NewFlagSet(c.Info().Name, gnuflag.ContinueOnError)
+		f := gnuflag.NewFlagSetWithFlagKnownAs(c.Info().Name, gnuflag.ContinueOnError, FlagAlias(subcmd, "flag"))
 		f.SetOutput(ioutil.Discard)
 		subcmd.SetFlags(f)
 	} else {

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -645,6 +645,24 @@ func (s *SuperCommandSuite) TestGlobalFlagsAfterCommand(c *gc.C) {
 	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "testoption\n")
 }
 
+func (s *SuperCommandSuite) TestSuperSetFlags(c *gc.C) {
+	sc := cmd.NewSuperCommand(cmd.SuperCommandParams{
+		UsagePrefix: "juju",
+		Name:        "command",
+		Log:         &cmd.Log{},
+		FlagKnownAs: "option",
+	})
+	sc.Register(&TestCommand{Name: "blah"})
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(sc, ctx, []string{
+		"blah",
+		"--fluffs",
+	})
+	c.Assert(code, gc.Equals, 2)
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "ERROR option provided but not defined: --fluffs\n")
+}
+
 type flagAdderFunc func(*gnuflag.FlagSet)
 
 func (f flagAdderFunc) AddFlags(fset *gnuflag.FlagSet) {

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -652,6 +652,19 @@ func (s *SuperCommandSuite) TestSuperSetFlags(c *gc.C) {
 		Log:         &cmd.Log{},
 		FlagKnownAs: "option",
 	})
+	s.assertFlagsAlias(c, sc, "option")
+}
+
+func (s *SuperCommandSuite) TestSuperSetFlagsDefault(c *gc.C) {
+	sc := cmd.NewSuperCommand(cmd.SuperCommandParams{
+		UsagePrefix: "juju",
+		Name:        "command",
+		Log:         &cmd.Log{},
+	})
+	s.assertFlagsAlias(c, sc, "flag")
+}
+
+func (s *SuperCommandSuite) assertFlagsAlias(c *gc.C, sc *cmd.SuperCommand, expectedAlias string) {
 	sc.Register(&TestCommand{Name: "blah"})
 	ctx := cmdtesting.Context(c)
 	code := cmd.Main(sc, ctx, []string{
@@ -660,7 +673,7 @@ func (s *SuperCommandSuite) TestSuperSetFlags(c *gc.C) {
 	})
 	c.Assert(code, gc.Equals, 2)
 	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
-	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "ERROR option provided but not defined: --fluffs\n")
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, fmt.Sprintf("ERROR %v provided but not defined: --fluffs\n", expectedAlias))
 }
 
 type flagAdderFunc func(*gnuflag.FlagSet)


### PR DESCRIPTION
My previous PR for customizing what command flags are know as, missed an internal flag set that is setup by Super command. This code path was also untested.

This PR refactors the logic to get flags alias and adds missing code bits.