### PR TITLE
Show desired super command flags in command help.

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -266,7 +266,7 @@ type Info struct {
 }
 
 // Help renders i's content, along with documentation for any
-// flags defined in f. It calls f.SetOutput(ioutil.Discard).
+// flags defined in f.
 func (i *Info) Help(f *gnuflag.FlagSet) []byte {
 	return i.HelpWithSuperFlags(nil, f)
 }
@@ -274,7 +274,6 @@ func (i *Info) Help(f *gnuflag.FlagSet) []byte {
 // HelpWithSuperFlags renders i's content, along with documentation for any
 // flags defined in both command and its super command flag sets.
 // Only super command flags defined in i.ShowSuperFlags are displayed, if found.
-// It calls FLagSet.SetOutput(ioutil.Discard).
 func (i *Info) HelpWithSuperFlags(superF *gnuflag.FlagSet, f *gnuflag.FlagSet) []byte {
 	buf := &bytes.Buffer{}
 	fmt.Fprintf(buf, "Usage: %s", i.Name)
@@ -301,13 +300,10 @@ func (i *Info) HelpWithSuperFlags(superF *gnuflag.FlagSet, f *gnuflag.FlagSet) [
 			}
 			return false
 		}
-		emptyFlag := &gnuflag.Flag{}
 		superF.VisitAll(func(flag *gnuflag.Flag) {
 			if contains(flag.Name) {
-				if found := filteredSuperF.Lookup(flag.Name); found == nil || found == emptyFlag {
-					hasSuperFlags = true
-					filteredSuperF.Var(flag.Value, flag.Name, flag.Usage)
-				}
+				hasSuperFlags = true
+				filteredSuperF.Var(flag.Value, flag.Name, flag.Usage)
 			}
 		})
 		if hasSuperFlags {

--- a/help.go
+++ b/help.go
@@ -194,7 +194,10 @@ func (c *helpCommand) getCommandHelp(super *SuperCommand, command Command, alias
 	}
 	f := gnuflag.NewFlagSetWithFlagKnownAs(info.Name, gnuflag.ContinueOnError, flagsAKA)
 	command.SetFlags(f)
-	return info.Help(f)
+
+	superf := gnuflag.NewFlagSetWithFlagKnownAs(super.Info().Name, gnuflag.ContinueOnError, flagsAKA)
+	super.SetFlags(superf)
+	return info.HelpWithSuperFlags(superf, f)
 }
 
 func (c *helpCommand) Run(ctx *Context) error {


### PR DESCRIPTION
When reading the help for a sub-command, it is also desirable to see supported options for super command.

For example, for 'juju help add-model', we'd want to see https://pastebin.ubuntu.com/p/yh59W4X68h/

This change enables to specify what super options are to display via info.ShowSuperFlags and adds logic to actual help display. We are grouping super command's options as 'global' and sub-command's options as 'command'.

 A new method was added info.HelpWithSuperFlags. For backward compatibility, old info.Help still exists but delegates to the new call.