### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/logging.go
+++ b/logging.go
@@ -137,7 +137,7 @@ type warningWriter struct {
 	writer *ansiterm.Writer
 }
 
-// NewColorWriter will write out colored severity levels if the writer is
+// NewWarningWriter will write out colored severity levels if the writer is
 // outputting to a terminal.
 func NewWarningWriter(writer io.Writer) loggo.Writer {
 	w := &warningWriter{ansiterm.NewWriter(writer)}


### PR DESCRIPTION
Hi, we updated an exported function comment based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?