### PR TITLE
Extended version command with version detail.

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -3,6 +3,6 @@
 
 package cmd
 
-func NewVersionCommand(version string) Command {
-	return newVersionCommand(version)
+func NewVersionCommand(version string, versionDetail interface{}) Command {
+	return newVersionCommand(version, versionDetail)
 }

--- a/help.go
+++ b/help.go
@@ -202,7 +202,7 @@ func (c *helpCommand) getCommandHelp(super *SuperCommand, command Command, alias
 
 func (c *helpCommand) Run(ctx *Context) error {
 	if c.super.showVersion {
-		v := newVersionCommand(c.super.version)
+		v := newVersionCommand(c.super.version, c.super.versionDetail)
 		v.SetFlags(c.super.flags)
 		v.Init(nil)
 		return v.Run(ctx)

--- a/supercommand.go
+++ b/supercommand.go
@@ -68,6 +68,10 @@ type SuperCommandParams struct {
 	MissingCallback MissingCallback
 	Aliases         []string
 	Version         string
+	// VersionDetail is a freeform information that is output when the default version
+	// subcommand is passed --all. Output is formatted using the user-selected formatter.
+	// Exported fields should specify yaml and json field tags.
+	VersionDetail interface{}
 
 	// UserAliasesFilename refers to the location of a file that contains
 	//   name = cmd [args...]
@@ -103,6 +107,7 @@ func NewSuperCommand(params SuperCommandParams) *SuperCommand {
 		usagePrefix:         params.UsagePrefix,
 		missingCallback:     params.MissingCallback,
 		version:             params.Version,
+		versionDetail:       params.VersionDetail,
 		notifyRun:           params.NotifyRun,
 		notifyHelp:          params.NotifyHelp,
 		userAliasesFilename: params.UserAliasesFilename,
@@ -145,6 +150,7 @@ type SuperCommand struct {
 	Aliases             []string
 	globalFlags         FlagAdder
 	version             string
+	versionDetail       interface{}
 	usagePrefix         string
 	userAliasesFilename string
 	userAliases         map[string][]string
@@ -191,7 +197,7 @@ func (c *SuperCommand) init() {
 	}
 	if c.version != "" {
 		c.subcmds["version"] = commandReference{
-			command: newVersionCommand(c.version),
+			command: newVersionCommand(c.version, c.versionDetail),
 		}
 	}
 

--- a/version.go
+++ b/version.go
@@ -10,13 +10,17 @@ import (
 // versionCommand is a cmd.Command that prints the current version.
 type versionCommand struct {
 	CommandBase
-	out     Output
-	version string
+	out           Output
+	version       string
+	versionDetail interface{}
+
+	showAll bool
 }
 
-func newVersionCommand(version string) *versionCommand {
+func newVersionCommand(version string, versionDetail interface{}) *versionCommand {
 	return &versionCommand{
-		version: version,
+		version:       version,
+		versionDetail: versionDetail,
 	}
 }
 
@@ -29,8 +33,12 @@ func (v *versionCommand) Info() *Info {
 
 func (v *versionCommand) SetFlags(f *gnuflag.FlagSet) {
 	v.out.AddFlags(f, "smart", DefaultFormatters)
+	f.BoolVar(&v.showAll, "all", false, "Prints all version information")
 }
 
 func (v *versionCommand) Run(ctxt *Context) error {
+	if v.showAll {
+		return v.out.Write(ctxt, v.versionDetail)
+	}
 	return v.out.Write(ctxt, v.version)
 }

--- a/version_test.go
+++ b/version_test.go
@@ -19,11 +19,17 @@ type VersionSuite struct {
 
 var _ = gc.Suite(&VersionSuite{})
 
+type versionDetail struct {
+	Version       string `json:"version"`
+	GitCommitHash string `json:"git-commit-hash"`
+	GitTreeState  string `json:"git-tree-state"`
+}
+
 func (s *VersionSuite) TestVersion(c *gc.C) {
 	const version = "999.888.777"
 
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(cmd.NewVersionCommand(version), ctx, nil)
+	code := cmd.Main(cmd.NewVersionCommand(version, nil), ctx, nil)
 	c.Check(code, gc.Equals, 0)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, version+"\n")
@@ -31,7 +37,7 @@ func (s *VersionSuite) TestVersion(c *gc.C) {
 
 func (s *VersionSuite) TestVersionExtraArgs(c *gc.C) {
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(cmd.NewVersionCommand("xxx"), ctx, []string{"foo"})
+	code := cmd.Main(cmd.NewVersionCommand("xxx", nil), ctx, []string{"foo"})
 	c.Check(code, gc.Equals, 2)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, "ERROR unrecognized args.*\n")
@@ -41,8 +47,25 @@ func (s *VersionSuite) TestVersionJson(c *gc.C) {
 	const version = "999.888.777"
 
 	ctx := cmdtesting.Context(c)
-	code := cmd.Main(cmd.NewVersionCommand(version), ctx, []string{"--format", "json"})
+	code := cmd.Main(cmd.NewVersionCommand(version, nil), ctx, []string{"--format", "json"})
 	c.Check(code, gc.Equals, 0)
 	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, fmt.Sprintf("%q\n", version))
+}
+
+func (s *VersionSuite) TestVersionDetailJson(c *gc.C) {
+	const version = "999.888.777"
+	detail := versionDetail{
+		Version:       version,
+		GitCommitHash: "46f1a0bd5592a2f9244ca321b129902a06b53e03",
+		GitTreeState:  "dirty",
+	}
+
+	ctx := cmdtesting.Context(c)
+	code := cmd.Main(cmd.NewVersionCommand(version, detail), ctx, []string{"--all", "--format", "json"})
+	c.Check(code, gc.Equals, 0)
+	c.Assert(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, `
+{"version":"999.888.777","git-commit-hash":"46f1a0bd5592a2f9244ca321b129902a06b53e03","git-tree-state":"dirty"}
+`[1:])
 }


### PR DESCRIPTION
Extended the version command so a SuperCommand can specify a greater detail of version information.