### PR TITLE
Template formatter and support for formatter args.

### DIFF
--- a/output.go
+++ b/output.go
@@ -9,17 +9,41 @@ import (
 	"io"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
+	"text/template"
 
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	goyaml "gopkg.in/yaml.v2"
 )
 
 // Formatter writes the arbitrary object into the writer.
-type Formatter func(writer io.Writer, value interface{}) error
+type Formatter interface {
+	Format(writer io.Writer, value interface{}) error
+}
 
-// FormatYaml writes out value as yaml to the writer, unless value is nil.
-func FormatYaml(writer io.Writer, value interface{}) error {
+// FormatterFunc writes the arbitrary object into the writer.
+type FormatterFunc func(writer io.Writer, value interface{}) error
+
+// Format writes the arbitrary object into the writer.
+func (f FormatterFunc) Format(writer io.Writer, value interface{}) error {
+	return f(writer, value)
+}
+
+// FormatterWithArgument writes the arbitrary object into the writer using
+// an optional argument.
+type FormatterWithArgument interface {
+	Formatter
+	// FormatWithArg is called instead when the formatter is passed an argument.
+	FormatWithArg(writer io.Writer, arg string, value interface{}) error
+	// ValidateArg is called when the formatter is selected with an argument.
+	// An error should be returned when the argument is malformed.
+	ValidateArg(arg string) error
+}
+
+// formatYamlFunc writes out value as yaml to the writer, unless value is nil.
+func formatYamlFunc(writer io.Writer, value interface{}) error {
 	if value == nil {
 		return nil
 	}
@@ -42,8 +66,8 @@ func FormatYaml(writer io.Writer, value interface{}) error {
 	return nil
 }
 
-// FormatJson writes out value as json.
-func FormatJson(writer io.Writer, value interface{}) error {
+// formatJsonFunc writes out value as json.
+func formatJsonFunc(writer io.Writer, value interface{}) error {
 	result, err := json.Marshal(value)
 	if err != nil {
 		return err
@@ -53,13 +77,13 @@ func FormatJson(writer io.Writer, value interface{}) error {
 	return err
 }
 
-// FormatSmart marshals value into a []byte according to the following rules:
+// formatSmartFunc marshals value into a []byte according to the following rules:
 //   * string:        untouched
 //   * bool:          converted to `True` or `False` (to match pyjuju)
 //   * int or float:  converted to sensible strings
 //   * []string:      joined by `\n`s into a single string
 //   * anything else: delegate to FormatYaml
-func FormatSmart(writer io.Writer, value interface{}) error {
+func formatSmartFunc(writer io.Writer, value interface{}) error {
 	if value == nil {
 		return nil
 	}
@@ -85,17 +109,67 @@ func FormatSmart(writer io.Writer, value interface{}) error {
 	return err
 }
 
+// formatTemplate writes out value according to the gotemplate arg.
+type formatTemplate struct{}
+
+func (f formatTemplate) Format(writer io.Writer, value interface{}) error {
+	return errors.New("--format template requires gotemplate argument")
+}
+
+func (f formatTemplate) FormatWithArg(writer io.Writer, arg string, value interface{}) error {
+	t, err := f.template(arg)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return errors.Trace(t.Execute(writer, value))
+}
+
+func (f formatTemplate) ValidateArg(arg string) error {
+	_, err := f.template(arg)
+	return errors.Trace(err)
+}
+
+func (f formatTemplate) template(arg string) (*template.Template, error) {
+	arg, err := strconv.Unquote(arg)
+	if err != nil {
+		return nil, errors.Annotate(err, "template must be passed with quotes")
+	}
+	t, err := template.New("format-template").Parse(arg)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return t, nil
+}
+
+var (
+	// FormatSmart marshals value into a []byte according to the following rules:
+	//   * string:        untouched
+	//   * bool:          converted to `True` or `False` (to match pyjuju)
+	//   * int or float:  converted to sensible strings
+	//   * []string:      joined by `\n`s into a single string
+	//   * anything else: delegate to FormatYaml
+	FormatSmart = FormatterFunc(formatSmartFunc)
+	// FormatYaml writes out value as yaml to the writer, unless value is nil.
+	FormatYaml = FormatterFunc(formatYamlFunc)
+	// FormatJson writes out value as json.
+	FormatJson = FormatterFunc(formatJsonFunc)
+	// FormatTemplate writes out value according to the gotemplate arg.
+	FormatTemplate = &formatTemplate{}
+)
+
 // DefaultFormatters holds the formatters that can be
 // specified with the --format flag.
 var DefaultFormatters = map[string]Formatter{
-	"smart": FormatSmart,
-	"yaml":  FormatYaml,
-	"json":  FormatJson,
+	"smart":    FormatSmart,
+	"yaml":     FormatYaml,
+	"json":     FormatJson,
+	"template": FormatTemplate,
 }
 
 // formatterValue implements gnuflag.Value for the --format flag.
 type formatterValue struct {
 	name       string
+	arg        string
 	formatters map[string]Formatter
 }
 
@@ -111,10 +185,27 @@ func newFormatterValue(initial string, formatters map[string]Formatter) *formatt
 
 // Set stores the chosen formatter name in v.name.
 func (v *formatterValue) Set(value string) error {
-	if v.formatters[value] == nil {
+	// formatter<=arg>
+	args := strings.SplitN(value, "=", 2)
+	name := args[0]
+	arg := ""
+	if len(args) == 2 {
+		arg = args[1]
+	}
+
+	formatter := v.formatters[name]
+	if formatter == nil {
 		return fmt.Errorf("unknown format %q", value)
 	}
-	v.name = value
+	v.name = name
+
+	if argFormatter, ok := formatter.(FormatterWithArgument); ok {
+		err := argFormatter.ValidateArg(arg)
+		if err != nil {
+			return errors.Annotatef(err, "formatter %s passed invalid argument %s", name, arg)
+		}
+		v.arg = arg
+	}
 	return nil
 }
 
@@ -133,11 +224,6 @@ func (v *formatterValue) doc() string {
 	}
 	sort.Strings(choices)
 	return "Specify output format (" + strings.Join(choices, "|") + ")"
-}
-
-// format runs the chosen formatter on value.
-func (v *formatterValue) format(writer io.Writer, value interface{}) error {
-	return v.formatters[v.name](writer, value)
 }
 
 // Output is responsible for interpreting output-related command line flags
@@ -159,6 +245,7 @@ func (c *Output) AddFlags(f *gnuflag.FlagSet, defaultFormatter string, formatter
 // --output command line flags.
 func (c *Output) Write(ctx *Context, value interface{}) (err error) {
 	formatterName := c.formatter.name
+	formatterArg := c.formatter.arg
 	formatter := c.formatter.formatters[formatterName]
 	// If the formatter is not one of the default ones, add a new line at the end.
 	// This keeps consistent behaviour with the current code.
@@ -166,7 +253,7 @@ func (c *Output) Write(ctx *Context, value interface{}) (err error) {
 	if _, found := DefaultFormatters[formatterName]; !found {
 		newline = true
 	}
-	if err := c.writeFormatter(ctx, formatter, value, newline); err != nil {
+	if err := c.writeFormatter(ctx, formatter, formatterArg, value, newline); err != nil {
 		return err
 	}
 	return nil
@@ -175,10 +262,10 @@ func (c *Output) Write(ctx *Context, value interface{}) (err error) {
 // WriteFormatter formats and outputs the value with the given formatter,
 // to the output directed by the --output command line flag.
 func (c *Output) WriteFormatter(ctx *Context, formatter Formatter, value interface{}) (err error) {
-	return c.writeFormatter(ctx, formatter, value, false)
+	return c.writeFormatter(ctx, formatter, "", value, false)
 }
 
-func (c *Output) writeFormatter(ctx *Context, formatter Formatter, value interface{}, newline bool) (err error) {
+func (c *Output) writeFormatter(ctx *Context, formatter Formatter, formatterArg string, value interface{}, newline bool) (err error) {
 	var target io.Writer
 	if c.outPath == "" {
 		target = ctx.Stdout
@@ -191,7 +278,11 @@ func (c *Output) writeFormatter(ctx *Context, formatter Formatter, value interfa
 		defer f.Close()
 		target = f
 	}
-	if err := formatter(target, value); err != nil {
+	if argFormatter, ok := formatter.(FormatterWithArgument); ok && formatterArg != "" {
+		if err := argFormatter.FormatWithArg(target, formatterArg, value); err != nil {
+			return err
+		}
+	} else if err := formatter.Format(target, value); err != nil {
 		return err
 	}
 	if newline {

--- a/output_test.go
+++ b/output_test.go
@@ -125,6 +125,32 @@ var outputTests = map[string][]struct {
 		{defaultValue, "juju: 1\npuppet: false\n"},
 		{overrideFormatter{cmd.FormatSmart, "abc\ndef"}, "abc\ndef\n"},
 	},
+	"yaml=ignored": {
+		{nil, ""},
+	},
+	`template="{{.}}"`: {
+		{nil, "<no value>"},
+		{"", ""},
+		{1, "1"},
+		{-1, "-1"},
+		{1.1, "1.1"},
+		{10000000, "10000000"},
+		{true, "true"},
+		{false, "false"},
+		{"hello", "hello"},
+		{"\n\n\n", "\n\n\n"},
+		{"foo: bar", "foo: bar"},
+		{[]string{}, "[]"},
+		{[]string{"blam", "dink"}, "[blam dink]"},
+		{defaultValue, "{1 false}"},
+		{overrideFormatter{cmd.FormatSmart, "abc\ndef"}, "abc\ndef\n"},
+	},
+	`template="{{.Puppet}}"`: {
+		{defaultValue, "false"},
+	},
+	`template="{{.Juju}}"`: {
+		{defaultValue, "1"},
+	},
 }
 
 func (s *CmdSuite) TestOutputFormat(c *gc.C) {


### PR DESCRIPTION
- Add support for advanced formatting of output via go templates, useful for scripts to filter output.
- Add support for formatters to take an argument, such as a template.

This is a breaking change for custom formatters. They need to cast the custom formatter func to a cmd.FormatterFunc.