### PR TITLE
force yaml/json output

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -108,13 +108,14 @@ func (c *CommandBase) AllowInterspersedFlags() bool {
 // should interpret file names relative to Dir (see AbsPath below), and print
 // output and errors to Stdout and Stderr respectively.
 type Context struct {
-	Dir     string
-	Env     map[string]string
-	Stdin   io.Reader
-	Stdout  io.Writer
-	Stderr  io.Writer
-	quiet   bool
-	verbose bool
+	Dir         string
+	Env         map[string]string
+	Stdin       io.Reader
+	Stdout      io.Writer
+	Stderr      io.Writer
+	quiet       bool
+	writeOutput func(err error) bool
+	verbose     bool
 }
 
 // Quiet reports whether the command is in "quiet" mode. When
@@ -381,7 +382,9 @@ func Main(c Command, ctx *Context, args []string) int {
 			return err.(*RcPassthroughError).Code
 		}
 		if err != ErrSilent {
-			WriteError(ctx.Stderr, err)
+			if !ctx.writeOutput(err) {
+				WriteError(ctx.Stderr, err)
+			}
 		}
 		return 1
 	}

--- a/cmd.go
+++ b/cmd.go
@@ -108,14 +108,13 @@ func (c *CommandBase) AllowInterspersedFlags() bool {
 // should interpret file names relative to Dir (see AbsPath below), and print
 // output and errors to Stdout and Stderr respectively.
 type Context struct {
-	Dir         string
-	Env         map[string]string
-	Stdin       io.Reader
-	Stdout      io.Writer
-	Stderr      io.Writer
-	quiet       bool
-	writeOutput func(err error) bool
-	verbose     bool
+	Dir     string
+	Env     map[string]string
+	Stdin   io.Reader
+	Stdout  io.Writer
+	Stderr  io.Writer
+	quiet   bool
+	verbose bool
 }
 
 // Quiet reports whether the command is in "quiet" mode. When
@@ -382,9 +381,7 @@ func Main(c Command, ctx *Context, args []string) int {
 			return err.(*RcPassthroughError).Code
 		}
 		if err != ErrSilent {
-			if !ctx.writeOutput(err) {
-				WriteError(ctx.Stderr, err)
-			}
+			WriteError(ctx.Stderr, err)
 		}
 		return 1
 	}

--- a/output.go
+++ b/output.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	goyaml "gopkg.in/yaml.v2"
 )
@@ -45,12 +46,12 @@ func FormatYaml(writer io.Writer, value interface{}) error {
 
 // FormatYaml writes out value as yaml to the writer, unless value is nil.
 func FormatErrYaml(writer io.Writer) error {
-	result, err := goyaml.Marshal(errResponse{})
+	result, err := goyaml.Marshal(struct{}{})
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	_, err = writer.Write(result)
-	return nil
+	return errors.Trace(err)
 }
 
 // FormatJson writes out value as json.
@@ -66,15 +67,12 @@ func FormatJson(writer io.Writer, value interface{}) error {
 
 // FormatJson writes out value as json.
 func FormatErrJson(writer io.Writer) error {
-	result, err := json.Marshal(errResponse{})
+	result, err := json.Marshal(struct{}{})
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	_, err = writer.Write(result)
-	return err
-}
-
-type errResponse struct {
+	return errors.Trace(err)
 }
 
 // FormatSmart marshals value into a []byte according to the following rules:

--- a/output.go
+++ b/output.go
@@ -17,7 +17,7 @@ import (
 
 // Formatter writes the arbitrary object into the writer.
 type Formatter func(writer io.Writer, value interface{}) error
-type ErrFormatter func(writer io.Writer, err error) error
+type ErrFormatter func(writer io.Writer) error
 
 // FormatYaml writes out value as yaml to the writer, unless value is nil.
 func FormatYaml(writer io.Writer, value interface{}) error {
@@ -44,21 +44,12 @@ func FormatYaml(writer io.Writer, value interface{}) error {
 }
 
 // FormatYaml writes out value as yaml to the writer, unless value is nil.
-func FormatErrYaml(writer io.Writer, err error) error {
-	code := 1
-	if IsRcPassthroughError(err) {
-		code = err.(*RcPassthroughError).Code
-	}
-	result, err := goyaml.Marshal(ErrorResponse{ErrorMsg: err.Error(), ExitCode: code})
+func FormatErrYaml(writer io.Writer) error {
+	result, err := goyaml.Marshal(errResponse{})
 	if err != nil {
 		return err
 	}
-
-	if len(result) > 0 {
-		result = append(result, '\n')
-		_, err = writer.Write(result)
-		return err
-	}
+	_, err = writer.Write(result)
 	return nil
 }
 
@@ -73,24 +64,17 @@ func FormatJson(writer io.Writer, value interface{}) error {
 	return err
 }
 
-type ErrorResponse struct {
-	ErrorMsg string `yaml:"error-msg" json:"error-msg"`
-	ExitCode int    `yaml:"exit-code" json:"exit-code"`
-}
-
 // FormatJson writes out value as json.
-func FormatErrJson(writer io.Writer, err error) error {
-	code := 1
-	if IsRcPassthroughError(err) {
-		code = err.(*RcPassthroughError).Code
-	}
-	result, err := json.Marshal(ErrorResponse{ErrorMsg: err.Error(), ExitCode: code})
+func FormatErrJson(writer io.Writer) error {
+	result, err := json.Marshal(errResponse{})
 	if err != nil {
 		return err
 	}
-	result = append(result, '\n')
 	_, err = writer.Write(result)
 	return err
+}
+
+type errResponse struct {
 }
 
 // FormatSmart marshals value into a []byte according to the following rules:

--- a/output_test.go
+++ b/output_test.go
@@ -47,6 +47,10 @@ type overrideFormatter struct {
 	value     interface{}
 }
 
+type overrideErrFormatter struct {
+	formatter cmd.ErrFormatter
+}
+
 // use a struct to control field ordering.
 var defaultValue = struct {
 	Juju   int
@@ -107,6 +111,7 @@ var outputTests = map[string][]struct {
 		{[]string{"blam", "dink"}, `["blam","dink"]` + "\n"},
 		{defaultValue, `{"Juju":1,"Puppet":false}` + "\n"},
 		{overrideFormatter{cmd.FormatSmart, "abc\ndef"}, "abc\ndef\n"},
+		{overrideErrFormatter{cmd.FormatErrJson}, "{}\n"},
 	},
 	"yaml": {
 		{nil, ""},
@@ -124,6 +129,7 @@ var outputTests = map[string][]struct {
 		{[]string{"blam", "dink"}, "- blam\n- dink\n"},
 		{defaultValue, "juju: 1\npuppet: false\n"},
 		{overrideFormatter{cmd.FormatSmart, "abc\ndef"}, "abc\ndef\n"},
+		{overrideErrFormatter{cmd.FormatErrYaml,}, "{}\n"},
 	},
 }
 


### PR DESCRIPTION
# Update
Error message on using formatting directives will now be omitted and an emtpy struct will be returned.

```
juju controllers --format=json
{}
juju models --format=json
{}
```

-----
# Old
## QA
Forcing output if formatting directives are given to be `"ErrorMsg": "<msg>"`

```
~/golang/src/github.com/juju/juju fix-err-stderr* 26s
❯ juju controllers --format=json
{"ErrorMsg":"No controllers registered.\n\nPlease either create a new controller using \"juju bootstrap\" or connect to\nanother controller that you have been given access to using \"juju register\".\n"}

```