### PR TITLE
adds an additional silent type

### DIFF
--- a/supercommand.go
+++ b/supercommand.go
@@ -514,7 +514,11 @@ func (c *SuperCommand) Run(ctx *Context) error {
 	}
 	err := c.action.command.Run(ctx)
 	if err != nil && !IsErrSilent(err) {
-		WriteError(ctx.Stderr, err)
+		if IsErrSilentPrintError(err) {
+			Write(ctx.Stderr, err)
+		} else {
+			WriteError(ctx.Stderr, err)
+		}
 		logger.Debugf("error stack: \n%v", errors.ErrorStack(err))
 		// Now that this has been logged, don't log again in cmd.Main.
 		if !IsRcPassthroughError(err) {


### PR DESCRIPTION
- adds an additional silent type
- makes sure that `errsilenttype` gets caught even if it wrapped
e.g. use-case 
```
ErrNoControllersDefined = &cmd.ErrSilentPrint{Msg: `No controllers registered.
	
	Please either create a new controller using "juju bootstrap" or connect to
	another controller that you have been given access to using "juju register".
	`, Code: 1}
```

in stdeer but no err wording.
```
juju add-user rick

 No controllers registered.
	
	Please either create a new controller using "juju bootstrap" or connect to
	another controller that you have been given access to using "juju register".
	
``` 