### PR TITLE
Output Type

### DIFF
--- a/output.go
+++ b/output.go
@@ -229,6 +229,39 @@ func (c *Output) writeFormatter(ctx *Context, formatter Formatter, value interfa
 	return nil
 }
 
+// Name represents the output of the current output formatting directive.
 func (c *Output) Name() string {
 	return c.formatter.name
+}
+
+// OutputType is used to describe what type of output the user can expect the
+// output format to be in.
+// In the future we can use this to know if to present stdout/stderr to an
+// operator if they request a machine type.
+type OutputType string
+
+const (
+	// MachineType represents an output that is intended to be consumed by a
+	// machine (script or automation). When a machine type is then used, things
+	// like interactivity should be disabled completely and instead default
+	// values should be returned.
+	MachineType OutputType = "machine"
+
+	// HumanReadableType represents output types where the user can interact
+	// with the tty session, so rich feedback is desired to help them through
+	// command line tasks.
+	HumanReadableType OutputType = "human-readable"
+)
+
+// Type represents the type of output of the current output formatting
+// directive.
+// For example, is the output a machine output (json, yaml) or is it designed to
+// be human readable (tabular).
+func (c *Output) Type() OutputType {
+	switch c.Name() {
+	case "json", "yaml":
+		return MachineType
+	default:
+		return HumanReadableType
+	}
 }

--- a/output_test.go
+++ b/output_test.go
@@ -129,7 +129,7 @@ var outputTests = map[string][]struct {
 		{[]string{"blam", "dink"}, "- blam\n- dink\n"},
 		{defaultValue, "juju: 1\npuppet: false\n"},
 		{overrideFormatter{cmd.FormatSmart, "abc\ndef"}, "abc\ndef\n"},
-		{overrideErrFormatter{cmd.FormatErrYaml,}, "{}\n"},
+		{overrideErrFormatter{cmd.FormatErrYaml}, "{}\n"},
 	},
 }
 
@@ -147,6 +147,29 @@ func (s *CmdSuite) TestOutputFormat(c *gc.C) {
 			c.Check(result, gc.Equals, 0)
 			c.Check(bufferString(ctx.Stdout), gc.Equals, t.output)
 			c.Check(bufferString(ctx.Stderr), gc.Equals, "")
+		}
+	}
+}
+
+func (s *CmdSuite) TestOutputFormatType(c *gc.C) {
+	for format, tests := range outputTests {
+		c.Logf("format %s", format)
+		var args []string
+		if format != "" {
+			args = []string{"--format", format}
+		}
+		for i, t := range tests {
+			c.Logf("  test %d", i)
+			ctx := cmdtesting.Context(c)
+			output := &OutputCommand{value: t.value}
+			_ = cmd.Main(output, ctx, args)
+
+			switch format {
+			case "json", "yaml":
+				c.Check(output.out.Type(), gc.Equals, cmd.MachineType)
+			default:
+				c.Check(output.out.Type(), gc.Equals, cmd.HumanReadableType)
+			}
 		}
 	}
 }


### PR DESCRIPTION
The following allows us to talk about the types of formatting directives
in terms of their intended output. With these changes we can create
better high level patterns when in the juju code base, ones that
understand if the output is directed at a machine or a human.

We should then be able to reason easily about the intention of the
output type, such that we can change the interaction between the
operator (script or human) depending on what they ask for.

If a machine asks for `json|yaml`, there should be zero interactive
behaviour. The opposite can then be deduced about human interaction,
where we plausibly want to have more interactivity to ease steep
learning curves.

This is just one step closer to giving juju command line a much richer
experience.