### PR TITLE
Machine context

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -115,6 +115,7 @@ type Context struct {
 	Stderr  io.Writer
 	quiet   bool
 	verbose bool
+	machine bool
 }
 
 // Quiet reports whether the command is in "quiet" mode. When
@@ -122,6 +123,13 @@ type Context struct {
 // messages can be used instead).
 func (ctx *Context) Quiet() bool {
 	return ctx.quiet
+}
+
+// Machine reports whether the command is required to output to a "machine".
+// This mode is intended to stop the proliferation of execessive writes to
+// stdout and stderr, when the output is intended for machines.
+func (ctx *Context) Machine() bool {
+	return ctx.machine
 }
 
 func (ctx *Context) write(format string, params ...interface{}) {

--- a/cmd.go
+++ b/cmd.go
@@ -108,14 +108,14 @@ func (c *CommandBase) AllowInterspersedFlags() bool {
 // should interpret file names relative to Dir (see AbsPath below), and print
 // output and errors to Stdout and Stderr respectively.
 type Context struct {
-	Dir     string
-	Env     map[string]string
-	Stdin   io.Reader
-	Stdout  io.Writer
-	Stderr  io.Writer
-	quiet   bool
-	verbose bool
-	machine bool
+	Dir          string
+	Env          map[string]string
+	Stdin        io.Reader
+	Stdout       io.Writer
+	Stderr       io.Writer
+	quiet        bool
+	verbose      bool
+	serialisable bool
 }
 
 // Quiet reports whether the command is in "quiet" mode. When
@@ -125,11 +125,11 @@ func (ctx *Context) Quiet() bool {
 	return ctx.quiet
 }
 
-// Machine reports whether the command is required to output to a "machine".
+// IsSerial reports whether the command is required to output to a "machine".
 // This mode is intended to stop the proliferation of execessive writes to
 // stdout and stderr, when the output is intended for machines.
-func (ctx *Context) Machine() bool {
-	return ctx.machine
+func (ctx *Context) IsSerial() bool {
+	return ctx.serialisable
 }
 
 func (ctx *Context) write(format string, params ...interface{}) {

--- a/output.go
+++ b/output.go
@@ -11,14 +11,12 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/juju/errors"
 	"github.com/juju/gnuflag"
 	goyaml "gopkg.in/yaml.v2"
 )
 
 // Formatter writes the arbitrary object into the writer.
 type Formatter func(writer io.Writer, value interface{}) error
-type ErrFormatter func(writer io.Writer) error
 
 // FormatYaml writes out value as yaml to the writer, unless value is nil.
 func FormatYaml(writer io.Writer, value interface{}) error {
@@ -44,16 +42,6 @@ func FormatYaml(writer io.Writer, value interface{}) error {
 	return nil
 }
 
-// FormatYaml writes out value as yaml to the writer, unless value is nil.
-func FormatErrYaml(writer io.Writer) error {
-	result, err := goyaml.Marshal(struct{}{})
-	if err != nil {
-		return errors.Trace(err)
-	}
-	_, err = writer.Write(result)
-	return errors.Trace(err)
-}
-
 // FormatJson writes out value as json.
 func FormatJson(writer io.Writer, value interface{}) error {
 	result, err := json.Marshal(value)
@@ -63,16 +51,6 @@ func FormatJson(writer io.Writer, value interface{}) error {
 	result = append(result, '\n')
 	_, err = writer.Write(result)
 	return err
-}
-
-// FormatJson writes out value as json.
-func FormatErrJson(writer io.Writer) error {
-	result, err := json.Marshal(struct{}{})
-	if err != nil {
-		return errors.Trace(err)
-	}
-	_, err = writer.Write(result)
-	return errors.Trace(err)
 }
 
 // FormatSmart marshals value into a []byte according to the following rules:
@@ -113,13 +91,6 @@ var DefaultFormatters = map[string]Formatter{
 	"smart": FormatSmart,
 	"yaml":  FormatYaml,
 	"json":  FormatJson,
-}
-
-// DefaultErrorFormatters holds the formatters that can be
-// specified with the --format flag.
-var DefaultErrorFormatters = map[string]ErrFormatter{
-	"yaml": FormatErrYaml,
-	"json": FormatErrJson,
 }
 
 // formatterValue implements gnuflag.Value for the --format flag.
@@ -229,6 +200,7 @@ func (c *Output) writeFormatter(ctx *Context, formatter Formatter, value interfa
 	return nil
 }
 
+// Name returns the underlying name of the formatter.
 func (c *Output) Name() string {
 	return c.formatter.name
 }

--- a/output.go
+++ b/output.go
@@ -85,12 +85,19 @@ func FormatSmart(writer io.Writer, value interface{}) error {
 	return err
 }
 
+// TypeFormatter describes a formatting type that can define if a type is
+// serialisable.
+type TypeFormatter struct {
+	Formatter    Formatter
+	Serialisable bool
+}
+
 // DefaultFormatters holds the formatters that can be
 // specified with the --format flag.
-var DefaultFormatters = map[string]Formatter{
-	"smart": FormatSmart,
-	"yaml":  FormatYaml,
-	"json":  FormatJson,
+var DefaultFormatters = map[string]TypeFormatter{
+	"smart": TypeFormatter{Formatter: FormatSmart, Serialisable: false},
+	"yaml":  TypeFormatter{Formatter: FormatYaml, Serialisable: true},
+	"json":  TypeFormatter{Formatter: FormatJson, Serialisable: true},
 }
 
 // formatterValue implements gnuflag.Value for the --format flag.

--- a/output_test.go
+++ b/output_test.go
@@ -28,7 +28,11 @@ func (c *OutputCommand) Info() *cmd.Info {
 }
 
 func (c *OutputCommand) SetFlags(f *gnuflag.FlagSet) {
-	c.out.AddFlags(f, "smart", cmd.DefaultFormatters)
+	formatters := make(map[string]cmd.Formatter, len(cmd.DefaultFormatters))
+	for k, v := range cmd.DefaultFormatters {
+		formatters[k] = v.Formatter
+	}
+	c.out.AddFlags(f, "smart", formatters)
 }
 
 func (c *OutputCommand) Init(args []string) error {

--- a/output_test.go
+++ b/output_test.go
@@ -47,10 +47,6 @@ type overrideFormatter struct {
 	value     interface{}
 }
 
-type overrideErrFormatter struct {
-	formatter cmd.ErrFormatter
-}
-
 // use a struct to control field ordering.
 var defaultValue = struct {
 	Juju   int
@@ -111,7 +107,7 @@ var outputTests = map[string][]struct {
 		{[]string{"blam", "dink"}, `["blam","dink"]` + "\n"},
 		{defaultValue, `{"Juju":1,"Puppet":false}` + "\n"},
 		{overrideFormatter{cmd.FormatSmart, "abc\ndef"}, "abc\ndef\n"},
-		{overrideErrFormatter{cmd.FormatErrJson}, "{}\n"},
+		{overrideFormatter{cmd.FormatJson, struct{}{}}, "{}\n"},
 	},
 	"yaml": {
 		{nil, ""},
@@ -129,7 +125,7 @@ var outputTests = map[string][]struct {
 		{[]string{"blam", "dink"}, "- blam\n- dink\n"},
 		{defaultValue, "juju: 1\npuppet: false\n"},
 		{overrideFormatter{cmd.FormatSmart, "abc\ndef"}, "abc\ndef\n"},
-		{overrideErrFormatter{cmd.FormatErrYaml,}, "{}\n"},
+		{overrideFormatter{cmd.FormatYaml, struct{}{}}, "{}\n"},
 	},
 }
 

--- a/supercommand.go
+++ b/supercommand.go
@@ -497,11 +497,18 @@ func (c *SuperCommand) Run(ctx *Context) error {
 	if c.action.command == nil {
 		panic("Run: missing subcommand; Init failed or not called")
 	}
+
+	// Set the machine state on the context, by checking the common global
+	// formatting directive. Set this early enough, so that everyone can take
+	// appropriate action further down stream.
+	ctx.machine = c.isMachineFormatDirective()
+
 	if c.Log != nil {
 		if err := c.Log.Start(ctx); err != nil {
 			return err
 		}
 	}
+
 	if c.notifyRun != nil {
 		name := c.Name
 		if c.usagePrefix != "" && c.usagePrefix != name {
@@ -512,16 +519,20 @@ func (c *SuperCommand) Run(ctx *Context) error {
 	if deprecated, replacement := c.action.Deprecated(); deprecated {
 		ctx.Infof("WARNING: %q is deprecated, please use %q", c.action.name, replacement)
 	}
+
 	err := c.action.command.Run(ctx)
 	if err != nil && !IsErrSilent(err) {
-		handleErr, done := c.handleFormattingDirective(ctx)
+		// Handle formatting when displaying errors.
+		handleErr := c.handleErrorForMachineFormats(ctx)
 		if handleErr != nil {
+			// If the error isn't a silent error, then dump out the error stack,
+			// which can be useful when debugging.
+			if handleErr != ErrSilent {
+				logger.Debugf("error stack: \n%v", errors.ErrorStack(err))
+			}
 			return handleErr
 		}
-		if done {
-			logger.Debugf("error stack: \n%v", errors.ErrorStack(err))
-			return nil
-		}
+
 		WriteError(ctx.Stderr, err)
 		logger.Debugf("error stack: \n%v", errors.ErrorStack(err))
 
@@ -535,20 +546,55 @@ func (c *SuperCommand) Run(ctx *Context) error {
 	return err
 }
 
-func (c *SuperCommand) handleFormattingDirective(ctx *Context) (error, bool) {
-	f := c.commonflags.Lookup("format")
-	if f == nil {
-		return nil, false
+// isMachineFormatDirective checks to see if the output format for a given
+// super command common flag (global), is intended to be used by a machine or
+// not.
+// It is expected that when this is set to true, extra actions are performed on
+// the output to mitigate addition verbose logging or interactivity.
+func (c *SuperCommand) isMachineFormatDirective() bool {
+	formatFlag := c.commonflags.Lookup("format")
+	if formatFlag == nil {
+		return false
 	}
-	formatter := DefaultErrorFormatters[f.Value.String()]
-	if formatter == nil {
-		return nil, false
+	formatName := formatFlag.Value.String()
+	if _, ok := DefaultFormatters[formatName]; !ok {
+		return false
 	}
-	err := formatter(ctx.Stderr)
+	switch formatName {
+	case "json", "yaml":
+		return true
+	default:
+		return false
+	}
+}
+
+// handleErrorForMachineFormats attempts to handle fatal errors when using
+// formatting directives.
+// If the formatting directive is what we consider a machine format (yaml or
+// json), then we attempt to output nothing for that format. An example of this
+// would be; for json, that would be {}.
+// No additional writes to stdout or stderr should be performed when a
+// successful format lookup is done, otherwise return errors from a unsuccessful
+// lookup.
+func (c *SuperCommand) handleErrorForMachineFormats(ctx *Context) error {
+	if !ctx.machine {
+		return nil
+	}
+
+	formatFlag := c.commonflags.Lookup("format")
+	if formatFlag == nil {
+		return nil
+	}
+	formatName := formatFlag.Value.String()
+	formatter, ok := DefaultFormatters[formatName]
+	if !ok {
+		return errors.Errorf("missing formatter %q", formatName)
+	}
+	err := formatter(ctx.Stderr, struct{}{})
 	if err != nil {
-		return err, true
+		return err
 	}
-	return ErrSilent, true
+	return ErrSilent
 }
 
 // FindClosestSubCommand attempts to find a sub command by a given name.

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -672,6 +672,7 @@ func (s *SuperCommandSuite) assertFlagsAlias(c *gc.C, sc *cmd.SuperCommand, expe
 		"--fluffs",
 	})
 	c.Assert(code, gc.Equals, 2)
+	c.Check(ctx.IsSerial(), gc.Equals, false)
 	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
 	c.Check(cmdtesting.Stderr(ctx), gc.Equals, fmt.Sprintf("ERROR %v provided but not defined: --fluffs\n", expectedAlias))
 }
@@ -714,7 +715,7 @@ func (s *SuperCommandSuite) assertFormattingErr(c *gc.C, sc *cmd.SuperCommand, f
 		"--option=error",
 	})
 	c.Assert(code, gc.Equals, 1)
-	c.Check(ctx.Machine(), gc.Equals, true)
+	c.Check(ctx.IsSerial(), gc.Equals, true)
 	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
 	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "{}\n")
 }

--- a/version.go
+++ b/version.go
@@ -32,7 +32,11 @@ func (v *versionCommand) Info() *Info {
 }
 
 func (v *versionCommand) SetFlags(f *gnuflag.FlagSet) {
-	v.out.AddFlags(f, "smart", DefaultFormatters)
+	formatters := make(map[string]Formatter, len(DefaultFormatters))
+	for k, v := range DefaultFormatters {
+		formatters[k] = v.Formatter
+	}
+	v.out.AddFlags(f, "smart", formatters)
 	f.BoolVar(&v.showAll, "all", false, "Prints all version information")
 }
 


### PR DESCRIPTION
The following allows us to talk about the types of formatting directives
in terms of their intended output. With these changes we can create
better high level patterns when in the juju code base, ones that
understand if the output is directed at a machine or a human.

We should then be able to reason easily about the intention of the
output type, such that we can change the interaction between the
operator (script or human) depending on what they ask for.

If a machine asks for json|yaml, there should be zero interactive
behaviour. The opposite can then be deduced about human interaction,
where we plausibly want to have more interactivity to ease steep
learning curves.

With the following code changes, we add a new member to the context
struct, one that allows us to know about the type of output that could
be happening. The machine method tells us that a operator/user has
requested a machine format and we should do our very best to honour that
by not outputting stdout/stderr messages that aren't in the correct
format.

---

Note: this removes the error formatting logic, as it's redundant once you
start talking about machine formatting vs human readable formatting.