### PR TITLE
Extract formatters

### DIFF
--- a/output.go
+++ b/output.go
@@ -92,9 +92,21 @@ type TypeFormatter struct {
 	Serialisable bool
 }
 
+type formatters map[string]TypeFormatter
+
+// Formatters returns the underlying formatters without the additional
+// information of a TypeFormatter.
+func (f formatters) Formatters() map[string]Formatter {
+	result := make(map[string]Formatter, len(f))
+	for k, v := range f {
+		result[k] = v.Formatter
+	}
+	return result
+}
+
 // DefaultFormatters holds the formatters that can be
 // specified with the --format flag.
-var DefaultFormatters = map[string]TypeFormatter{
+var DefaultFormatters = formatters{
 	"smart": TypeFormatter{Formatter: FormatSmart, Serialisable: false},
 	"yaml":  TypeFormatter{Formatter: FormatYaml, Serialisable: true},
 	"json":  TypeFormatter{Formatter: FormatJson, Serialisable: true},

--- a/output_test.go
+++ b/output_test.go
@@ -169,3 +169,14 @@ func (s *CmdSuite) TestFormatAlternativeSyntax(c *gc.C) {
 	c.Assert(result, gc.Equals, 0)
 	c.Assert(bufferString(ctx.Stdout), gc.Equals, "null\n")
 }
+
+func (s *CmdSuite) TestFormatters(c *gc.C) {
+	typeFormatters := cmd.DefaultFormatters
+	formatters := typeFormatters.Formatters()
+
+	c.Assert(len(typeFormatters), gc.Equals, len(formatters))
+	for k := range typeFormatters {
+		_, ok := formatters[k]
+		c.Assert(ok, gc.Equals, true)
+	}
+}


### PR DESCRIPTION
The following extracts the formatters from a type formatter. The type
formatter contains more information than a formatter, but some things
don't care about that information, so we need to uncompose the formatter
from the type.