### PR TITLE
Handle stderr vs stdout

### DIFF
--- a/supercommand.go
+++ b/supercommand.go
@@ -585,7 +585,12 @@ func (c *SuperCommand) handleErrorForMachineFormats(ctx *Context) error {
 	if !ok {
 		return errors.Errorf("missing formatter %q", formatName)
 	}
-	err := typeFormatter.Formatter(ctx.Stderr, struct{}{})
+	// Although this code handles errors for machine formats, the actual empty
+	// type should be written to stdout. This allows consumers of the output to
+	// correctly handle the resulting empty value.
+	// If we place it into stderr, it means that you can never add any more
+	// additional information to stderr, even if it helps the user.
+	err := typeFormatter.Formatter(ctx.Stdout, struct{}{})
 	if err != nil {
 		return err
 	}

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -716,8 +716,8 @@ func (s *SuperCommandSuite) assertFormattingErr(c *gc.C, sc *cmd.SuperCommand, f
 	})
 	c.Assert(code, gc.Equals, 1)
 	c.Check(ctx.IsSerial(), gc.Equals, true)
-	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "")
-	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "{}\n")
+	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "{}\n")
 }
 
 type flagAdderFunc func(*gnuflag.FlagSet)


### PR DESCRIPTION
When attempting to handle stdout vs stderr for formatting directives it
turns out that it's none-trivial and we should be really consistent with
where our stdout and stderr messages go.

With that in mind, the changes here ensure that when we encounter an
error for a machine format, the EMPTY value for each format is correctly
rendered to the STDOUT and not STDERR.

stderr is useful for error messages and until we have an appropriate way
of putting logs for CLI commands, we should use stderr for constructive
information that the consumer can use.

For scripting, stderr can always be redirected 2>/dev/null or to any
file so they can view what went wrong at a later date.