### PR TITLE
Log out stderr

### DIFF
--- a/supercommand.go
+++ b/supercommand.go
@@ -524,7 +524,7 @@ func (c *SuperCommand) Run(ctx *Context) error {
 	if err != nil && !IsErrSilent(err) {
 		// Handle formatting when displaying errors.
 		handleErr := c.handleErrorForMachineFormats(ctx)
-		if handleErr != nil && handleErr != ErrSilent {
+		if handleErr != nil {
 			// If the error isn't a silent error, then dump out the error stack,
 			// which can be useful when debugging.
 			logger.Debugf("error stack: \n%v", errors.ErrorStack(err))
@@ -588,11 +588,7 @@ func (c *SuperCommand) handleErrorForMachineFormats(ctx *Context) error {
 	// correctly handle the resulting empty value.
 	// If we place it into stderr, it means that you can never add any more
 	// additional information to stderr, even if it helps the user.
-	err := typeFormatter.Formatter(ctx.Stdout, struct{}{})
-	if err != nil {
-		return err
-	}
-	return ErrSilent
+	return typeFormatter.Formatter(ctx.Stdout, struct{}{})
 }
 
 // FindClosestSubCommand attempts to find a sub command by a given name.

--- a/supercommand.go
+++ b/supercommand.go
@@ -524,12 +524,10 @@ func (c *SuperCommand) Run(ctx *Context) error {
 	if err != nil && !IsErrSilent(err) {
 		// Handle formatting when displaying errors.
 		handleErr := c.handleErrorForMachineFormats(ctx)
-		if handleErr != nil {
+		if handleErr != nil && handleErr != ErrSilent {
 			// If the error isn't a silent error, then dump out the error stack,
 			// which can be useful when debugging.
-			if handleErr != ErrSilent {
-				logger.Debugf("error stack: \n%v", errors.ErrorStack(err))
-			}
+			logger.Debugf("error stack: \n%v", errors.ErrorStack(err))
 			return handleErr
 		}
 

--- a/supercommand.go
+++ b/supercommand.go
@@ -525,8 +525,10 @@ func (c *SuperCommand) Run(ctx *Context) error {
 		// Handle formatting when displaying errors.
 		handleErr := c.handleErrorForMachineFormats(ctx)
 		if handleErr != nil {
-			// If the error isn't a silent error, then dump out the error stack,
-			// which can be useful when debugging.
+			// If there is a handle error when attempting to find the machine
+			// format, we should let the user know. In doing so, we dump the
+			// original error and return the handle error so that effective
+			// debugging is possible.
 			logger.Debugf("error stack: \n%v", errors.ErrorStack(err))
 			return handleErr
 		}

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -716,7 +716,7 @@ func (s *SuperCommandSuite) assertFormattingErr(c *gc.C, sc *cmd.SuperCommand, f
 	})
 	c.Assert(code, gc.Equals, 1)
 	c.Check(ctx.IsSerial(), gc.Equals, true)
-	c.Check(cmdtesting.Stderr(ctx), gc.Equals, "")
+	c.Check(cmdtesting.Stderr(ctx), gc.Matches, "ERROR BAM!\n")
 	c.Check(cmdtesting.Stdout(ctx), gc.Equals, "{}\n")
 }
 


### PR DESCRIPTION
So previous PRs attempted to ensure we logged the empty value to stdout
and forsake all errors to stderr. This was a miss step, infact we should
still print to stderr as it is extremely useful.

The way juju currently operates with stderr is very opinionated and we
should be very consistent with those opinions, failure to do that breaks
a lot of commands in juju directly.

The following commit fixes the issue by always dumping out to stderr
even when we have an empty value.

In the future there should be a better place to put that, be we live in
the present and that day isn't here yet. But we should plan for it!