### PR TITLE
[JUJU-2217] Extended help documentation command

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -268,6 +268,12 @@ type Info struct {
 	// Doc is the long documentation for the Command.
 	Doc string
 
+	// Examples is a collection of running examples.
+	Examples []string
+
+	// SeeAlso is a collection of additional commands to be checked.
+	SeeAlso []string
+
 	// Aliases are other names for the Command.
 	Aliases []string
 

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -388,14 +388,3 @@ type CmdDocumentationSuite struct {
 
 	targetCmd cmd.Command
 }
-
-// func (s *CmdDocumentationSuite) TestDocumentationOutput(c *gc.C) {
-// 	subCmdA := &TestCommand{Name: "subCmdA"}
-// 	subCmdB := &TestCommand{Name: "subCmdB"}
-// 	params := cmd.SuperCommandParams{
-// 		Name:    "superCmd",
-// 		Doc:     "superCmd-Doc",
-// 		Version: "v1.0.0",
-// 	}
-// 	superCmd := cmd.NewSuperCommand(params)
-// }

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -23,6 +23,7 @@ import (
 
 var _ = gc.Suite(&CmdSuite{})
 var _ = gc.Suite(&CmdHelpSuite{})
+var _ = gc.Suite(&CmdDocumentationSuite{})
 
 type CmdSuite struct {
 	testing.LoggingCleanupSuite
@@ -381,3 +382,20 @@ Details:
 command details
 `[1:])
 }
+
+type CmdDocumentationSuite struct {
+	testing.LoggingCleanupSuite
+
+	targetCmd cmd.Command
+}
+
+// func (s *CmdDocumentationSuite) TestDocumentationOutput(c *gc.C) {
+// 	subCmdA := &TestCommand{Name: "subCmdA"}
+// 	subCmdB := &TestCommand{Name: "subCmdB"}
+// 	params := cmd.SuperCommandParams{
+// 		Name:    "superCmd",
+// 		Doc:     "superCmd-Doc",
+// 		Version: "v1.0.0",
+// 	}
+// 	superCmd := cmd.NewSuperCommand(params)
+// }

--- a/documentation.go
+++ b/documentation.go
@@ -125,7 +125,25 @@ func (c *documentationCommand) formatCommand(ref commandReference) string {
 	// Description
 	doc := ref.command.Info().Doc
 	if doc != "" {
-		formatted += "## Description\n" + ref.command.Info().Doc + "\n"
+		formatted += "## Description\n" + ref.command.Info().Doc + "\n\n"
+	}
+
+	// Examples
+	if len(ref.command.Info().Examples) > 0 {
+		formatted += "## Examples\n"
+		for _, e := range ref.command.Info().Examples {
+			formatted += "`" + e + "`\n"
+		}
+		formatted += "\n"
+	}
+
+	// See Also
+	if len(ref.command.Info().SeeAlso) > 0 {
+		formatted += "## See Also\n"
+		for _, s := range ref.command.Info().SeeAlso {
+			formatted += fmt.Sprintf("[%s](#%s)\n", s, s)
+		}
+		formatted += "\n"
 	}
 
 	formatted += "---\n"

--- a/documentation.go
+++ b/documentation.go
@@ -113,7 +113,7 @@ func (c *documentationCommand) formatCommand(ref commandReference) string {
 
 	// Arguments
 	if ref.command.Info().Args != "" {
-		formatted += "## Arguments\n" + ref.command.Info().Args + "\n\n"
+		formatted += "## Arguments\n```" + ref.command.Info().Args + "```\n\n"
 	}
 
 	// Description

--- a/documentation.go
+++ b/documentation.go
@@ -32,7 +32,7 @@ func (c *documentationCommand) Info() *Info {
 	return &Info{
 		Name:    "documentation",
 		Args:    "--out <target-file> --noindex",
-		Purpose: "Generate the documentation for current commands",
+		Purpose: "Generate the documentation for all commands",
 		Doc:     doc,
 	}
 }

--- a/documentation.go
+++ b/documentation.go
@@ -60,6 +60,7 @@ func (c *documentationCommand) Run(ctx *Context) error {
 
 func (c *documentationCommand) dumpEntries(writer *bufio.Writer) error {
 	if len(c.super.subcmds) == 0 {
+		fmt.Printf("No commands found for %s", c.super.Name)
 		return nil
 	}
 
@@ -157,13 +158,14 @@ func (c *documentationCommand) formatCommand(ref commandReference) string {
 // to permit additional formatting without modifying the
 // gnuflag package.
 func (d *documentationCommand) formatFlags(c Command) string {
-	flagsAKA := FlagAlias(c, "")
-	if flagsAKA == "" {
+	flagsAlias := FlagAlias(c, "")
+	if flagsAlias == "" {
 		// For backward compatibility, the default is 'flag'.
-		flagsAKA = "flag"
+		flagsAlias = "flag"
 	}
-	f := gnuflag.NewFlagSetWithFlagKnownAs(c.Info().Name, gnuflag.ContinueOnError, flagsAKA)
+	f := gnuflag.NewFlagSetWithFlagKnownAs(c.Info().Name, gnuflag.ContinueOnError, flagsAlias)
 	c.SetFlags(f)
+
 	// group together all flags for a given value
 	flags := make(map[interface{}]flagsByLength)
 	f.VisitAll(func(f *gnuflag.Flag) {

--- a/documentation.go
+++ b/documentation.go
@@ -1,0 +1,129 @@
+// Copyright 2012-2022 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENSE file for details.
+
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/juju/gnuflag"
+)
+
+var doc string = `
+This command generates a markdown formatted document with all the commands, their descriptions, arguments, and examples.
+`
+
+type documentationCommand struct {
+	CommandBase
+	super   *SuperCommand
+	out     string
+	noIndex bool
+}
+
+func newDocumentationCommand(s *SuperCommand) *documentationCommand {
+	return &documentationCommand{super: s}
+}
+
+func (c *documentationCommand) Info() *Info {
+	return &Info{
+		Name:    "documentation",
+		Args:    "--out <target-file> --noindex",
+		Purpose: "Generate the documentation for current commands",
+		Doc:     doc,
+	}
+}
+
+// SetFlags adds command specific flags to the flag set.
+func (c *documentationCommand) SetFlags(f *gnuflag.FlagSet) {
+	f.StringVar(&c.out, "out", "", "Documentation output file")
+	f.BoolVar(&c.noIndex, "noindex", false, "Do not generate the commands index")
+}
+
+func (c *documentationCommand) Run(ctx *Context) error {
+	var writer *bufio.Writer
+	if c.out != "" {
+		f, err := os.Create(c.out)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		writer = bufio.NewWriter(f)
+	} else {
+		writer = bufio.NewWriter(ctx.Stdout)
+	}
+	return c.dumpEntries(writer)
+}
+
+func (c *documentationCommand) dumpEntries(writer *bufio.Writer) error {
+	if len(c.super.subcmds) == 0 {
+		return nil
+	}
+
+	// sort the commands
+	sorted := make([]string, len(c.super.subcmds))
+	i := 0
+	for k := range c.super.subcmds {
+		sorted[i] = k
+		i++
+	}
+	sort.Strings(sorted)
+
+	if !c.noIndex {
+		_, err := writer.WriteString(c.commandsIndex(sorted))
+		if err != nil {
+			return err
+		}
+	}
+
+	var err error
+	for _, nameCmd := range sorted {
+		_, err = writer.WriteString(c.formatCommand(c.super.subcmds[nameCmd]))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *documentationCommand) commandsIndex(listCommands []string) string {
+	index := "# Index\n"
+	for id, name := range listCommands {
+		index += fmt.Sprintf("%d. [%s](#%s)\n", id, name, name)
+	}
+	index += "---\n\n"
+	return index
+}
+
+func (c *documentationCommand) formatCommand(ref commandReference) string {
+	formatted := "# " + strings.ToUpper(ref.name) + "\n"
+	if ref.alias != "" {
+		formatted += "**Alias:** " + ref.alias + "\n"
+	}
+	if ref.check != nil && ref.check.Obsolete() {
+		formatted += "*This command is deprecated*\n"
+	}
+	formatted += "\n"
+
+	// Description
+	formatted += "## Summary\n" + ref.command.Info().Purpose + "\n\n"
+
+	// Arguments
+	if ref.command.Info().Args != "" {
+		formatted += "## Arguments\n" + ref.command.Info().Args + "\n\n"
+	}
+
+	// Description
+	doc := ref.command.Info().Doc
+	if doc != "" {
+		formatted += "## Description\n" + ref.command.Info().Doc + "\n"
+	}
+
+	formatted += "---\n"
+
+	return formatted
+
+}

--- a/help.go
+++ b/help.go
@@ -113,6 +113,7 @@ func (c *helpCommand) Init(args []string) error {
 	if c.super.notifyHelp != nil {
 		c.super.notifyHelp(args)
 	}
+
 	logger.Tracef("helpCommand.Init: %#v", args)
 	if len(args) == 0 {
 		// If there is no help topic specified, print basic usage if it is

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -47,8 +47,9 @@ type SuperCommandSuite struct {
 
 var _ = gc.Suite(&SuperCommandSuite{})
 
+const docText = "\n    documentation\\s+- Generate the documentation for all commands"
 const helpText = "\n    help\\s+- Show help on a command or other topic."
-const helpCommandsText = "commands:" + helpText
+const helpCommandsText = "commands:" + docText + helpText
 
 func (s *SuperCommandSuite) TestDispatch(c *gc.C) {
 	jc := cmd.NewSuperCommand(cmd.SuperCommandParams{Name: "jujutest"})
@@ -62,7 +63,7 @@ func (s *SuperCommandSuite) TestDispatch(c *gc.C) {
 	info = jc.Info()
 	c.Assert(info.Name, gc.Equals, "jujutest")
 	c.Assert(info.Args, gc.Equals, "<command> ...")
-	c.Assert(info.Doc, gc.Matches, "commands:\n    defenestrate - defenestrate the juju"+helpText)
+	c.Assert(info.Doc, gc.Matches, "commands:\n    defenestrate  - defenestrate the juju"+docText+helpText)
 
 	jc, tc, err := initDefenestrate([]string{"defenestrate"})
 	c.Assert(err, gc.IsNil)
@@ -132,16 +133,18 @@ func (s *SuperCommandSuite) TestAliasesRegistered(c *gc.C) {
 
 	info := jc.Info()
 	c.Assert(info.Doc, gc.Equals, `commands:
-    flap - Alias for 'flip'.
-    flip - flip the juju
-    flop - Alias for 'flip'.
-    help - Show help on a command or other topic.`)
+    documentation - Generate the documentation for all commands
+    flap          - Alias for 'flip'.
+    flip          - flip the juju
+    flop          - Alias for 'flip'.
+    help          - Show help on a command or other topic.`)
 }
 
 func (s *SuperCommandSuite) TestInfo(c *gc.C) {
 	commandsDoc := `commands:
-    flapbabble - flapbabble the juju
-    flip       - flip the juju`
+    documentation - Generate the documentation for all commands
+    flapbabble    - flapbabble the juju
+    flip          - flip the juju`
 
 	jc := cmd.NewSuperCommand(cmd.SuperCommandParams{
 		Name:    "jujutest",
@@ -438,9 +441,10 @@ func (s *SuperCommandSuite) TestRegisterAlias(c *gc.C) {
 	info := jc.Info()
 	// NOTE: deprecated `bar` not shown in commands.
 	c.Assert(info.Doc, gc.Equals, `commands:
-    foo  - Alias for 'test'.
-    help - Show help on a command or other topic.
-    test - to be simple`)
+    documentation - Generate the documentation for all commands
+    foo           - Alias for 'test'.
+    help          - Show help on a command or other topic.
+    test          - to be simple`)
 
 	for _, test := range []struct {
 		name   string
@@ -502,10 +506,11 @@ func (s *SuperCommandSuite) TestRegisterSuperAlias(c *gc.C) {
 	info := jc.Info()
 	// NOTE: deprecated `bar` not shown in commands.
 	c.Assert(info.Doc, gc.Equals, `commands:
-    bar     - bar functions
-    bar-foo - Alias for 'bar foo'.
-    help    - Show help on a command or other topic.
-    test    - to be simple`)
+    bar           - bar functions
+    bar-foo       - Alias for 'bar foo'.
+    documentation - Generate the documentation for all commands
+    help          - Show help on a command or other topic.
+    test          - to be simple`)
 
 	for _, test := range []struct {
 		args   []string


### PR DESCRIPTION
The `documentation` command is added as a default option to generate a Markdown formatted documentation file with all the corresponding available information in a more friendly format. This PR is a first iteration to find a default format. After some back and forth, I have also extended the `Info` struct to include `Examples` and `SeeAlso`. This addition will help us differentiate this entries from the more general documentation description and to generate the corresponding entries in the generated output.

When used by juju, by running `juju documentation` we get an index followed by the list of existing commands. If the `--no-index` flag is used, this is not generated. The example below is an excerpt obtained with Juju.

---

# Index
0. [actions](#actions)
1. [add-cloud](#add-cloud)
....
# ADD-CLOUD

## Summary
Add a cloud definition to Juju.

## Usage
```<cloud name> [<cloud definition file>]```

## Options
| Flag | Default | Usage |
| --- | --- | --- |
| `--B`, `--no-browser-login` | false | Do not use web browser for authentication |
| `--c`, `--controller` |  | Controller to operate in |
| `--client` | false | Client operation |
| `--credential` |  | Credential to use for new cloud |
| `--f`, `--file` |  | The path to a cloud definition file |
| `--force` | false | Force add cloud to the controller |

## Description

Juju needs to know how to connect to clouds. A cloud definition 
describes a cloud's endpoints and authentication requirements. Each
definition is stored and accessed later as <cloud name>.

If you are accessing a public cloud, running add-cloud is unlikely to be 
necessary.  Juju already contains definitions for the public cloud 
providers it supports.

add-cloud operates in two modes:

    juju add-cloud
    juju add-cloud <cloud name> <cloud definition file>

When invoked without arguments, add-cloud begins an interactive session
designed for working with private clouds.  The session will enable you 
to instruct Juju how to connect to your private cloud.

A cloud definition can be provided in a file either as an option -f or as a 
positional argument:

    juju add-cloud mycloud ~/mycloud.yaml
    juju add-cloud mycloud -f ~/mycloud.yaml

When <cloud definition file> is provided with <cloud name>,
Juju will validate the content of the file and add this cloud 
to this client as well as upload it to a controller.

Use --controller option to upload a cloud to a controller. 

Use --client option to add cloud to the current client.

A cloud definition file has the following YAML format:

clouds:                           # mandatory
  mycloud:                        # <cloud name> argument
    type: openstack               # <cloud type>, see below
    auth-types: [ userpass ]
    regions:
      london:
        endpoint: https://london.mycloud.com:35574/v3.0/

<cloud types> for private clouds: 
 - lxd
 - maas
 - manual
 - openstack
 - vsphere

<cloud types> for public clouds:
 - azure
 - ec2
 - gce
 - oci

When a running controller is updated, the credential for the cloud
is also uploaded. As with the cloud, the credential needs
to have been added to the current client, use add-credential to
do that. If there's only one credential for the cloud it will be
uploaded to the controller automatically by add-cloud command. 
However, if the cloud has multiple credentials on this client
you can specify which to upload with the --credential option.

When adding clouds to a controller, some clouds are whitelisted and can be easily added:
 - controller cloud type "kubernetes" supports [lxd maas openstack]
 - controller cloud type "lxd" supports [lxd maas openstack]
 - controller cloud type "maas" supports [maas openstack]
 - controller cloud type "openstack" supports [openstack]

Other cloud combinations can only be force added as the user must consider
network routability, etc - concerns that are outside of scope of Juju.
When forced addition is desired, use --force.

Examples:
    juju add-cloud
    juju add-cloud --force
    juju add-cloud mycloud ~/mycloud.yaml
    juju add-cloud --controller mycontroller mycloud 
    juju add-cloud --controller mycontroller mycloud --credential mycred
    juju add-cloud --client mycloud ~/mycloud.yaml

See also: 
    clouds
    update-cloud
    remove-cloud
    update-credential
## Examples
`juju add-cloud`
`juju add-cloud --force`
`juju add-cloud mycloud ~/mycloud.yaml`
`juju add-cloud --controller mycontroller mycloud`
`juju add-cloud --controller mycontroller mycloud --credential mycred`
`juju add-cloud --client mycloud ~/mycloud.yaml`

## See Also
[clouds](#clouds)
[update-cloud](#update-cloud)
[remove-cloud](#remove-cloud)
[update-credential](#update-credential)
---

