### PR TITLE
Add Errorf method to Context

### DIFF
--- a/output_test.go
+++ b/output_test.go
@@ -155,8 +155,8 @@ func (s *CmdSuite) TestUnknownOutputFormat(c *gc.C) {
 	ctx := cmdtesting.Context(c)
 	result := cmd.Main(&OutputCommand{}, ctx, []string{"--format", "cuneiform"})
 	c.Check(result, gc.Equals, 2)
-	c.Check(bufferString(ctx.Stdout), gc.Equals, "")
-	c.Check(bufferString(ctx.Stderr), gc.Matches, ".*: unknown format \"cuneiform\"\n")
+	c.Check(bufferString(ctx.Stderr), gc.Equals, "")
+	c.Check(c.GetTestLog(), gc.Matches, ".*: unknown format \"cuneiform\"\n")
 }
 
 // Py juju allowed both --format json and --format=json. This test verifies that juju is

--- a/supercommand.go
+++ b/supercommand.go
@@ -517,7 +517,7 @@ func (c *SuperCommand) Run(ctx *Context) error {
 		c.notifyRun(name)
 	}
 	if deprecated, replacement := c.action.Deprecated(); deprecated {
-		ctx.Infof("WARNING: %q is deprecated, please use %q", c.action.name, replacement)
+		ctx.Warningf("%q is deprecated, please use %q", c.action.name, replacement)
 	}
 
 	err := c.action.command.Run(ctx)

--- a/version_test.go
+++ b/version_test.go
@@ -40,7 +40,7 @@ func (s *VersionSuite) TestVersionExtraArgs(c *gc.C) {
 	code := cmd.Main(cmd.NewVersionCommand("xxx", nil), ctx, []string{"foo"})
 	c.Check(code, gc.Equals, 2)
 	c.Assert(cmdtesting.Stdout(ctx), gc.Equals, "")
-	c.Assert(cmdtesting.Stderr(ctx), gc.Matches, "ERROR unrecognized args.*\n")
+	c.Assert(c.GetTestLog(), gc.Matches, `(?s).*unrecognized args.*`)
 }
 
 func (s *VersionSuite) TestVersionJson(c *gc.C) {


### PR DESCRIPTION
This will allow users to log errors causing failure from a commands context, without requiring exiting immediately, allowing for finer grain controller over error logging.

For instance, this may be useful when a command wishes to log multiple errors causing failure, or if the command has performed multiple actions, only some of which have failed.

Also deprecate WriteError in favour of ctx.Errorf

Fix tests. Errorf logs using a logger, however WriteError creates it's own ansiterm writer. This means logging output is now captured by `c.GetTestLog`, which we should match against a regex

Also, as a flyby, log alias deprecation warnings as Warnings.

## QA Steps

Verify unit tests pass

Use `ctx.Errorf` in the juju client, and build using this version of juju/cmd. Then verify that your message is logged at ERROR level severity