### PR TITLE
[JUJU-2309] Rewrite tests to set default writer in setup

### DIFF
--- a/cmdtesting/cmd.go
+++ b/cmdtesting/cmd.go
@@ -89,7 +89,7 @@ func RunCommandInDir(c *gc.C, com cmd.Command, args []string, dir string) (*cmd.
 
 func runCommand(ctx *cmd.Context, com cmd.Command, args []string) (*cmd.Context, error) {
 	if err := InitCommand(com, args); err != nil {
-		cmd.WriteError(ctx.Stderr, err)
+		ctx.Errorf("%s", err)
 		return ctx, err
 	}
 	return ctx, com.Run(ctx)

--- a/logging.go
+++ b/logging.go
@@ -91,7 +91,7 @@ func (log *Log) Start(ctx *Context) error {
 			return err
 		}
 	} else {
-		loggo.RemoveWriter("default")
+		_, _ = loggo.RemoveWriter("default")
 		// Create a simple writer that doesn't show filenames, or timestamps,
 		// and only shows warning or above.
 		writer := NewWarningWriter(ctx.Stderr)
@@ -145,7 +145,7 @@ func NewWarningWriter(writer io.Writer) loggo.Writer {
 }
 
 // Write implements Writer.
-//   WARNING The message...
+// WARNING The message...
 func (w *warningWriter) Write(entry loggo.Entry) {
 	loggocolor.SeverityColor[entry.Level].Fprintf(w.writer, entry.Level.String())
 	fmt.Fprintf(w.writer, " %s\n", entry.Message)

--- a/logging_test.go
+++ b/logging_test.go
@@ -44,11 +44,12 @@ func (s *LogSuite) TestNoFlags(c *gc.C) {
 }
 
 func (s *LogSuite) TestFlags(c *gc.C) {
-	log := newLogWithFlags(c, "", "--log-file", "foo", "--verbose", "--debug",
+	log := newLogWithFlags(c, "", "--log-file", "foo", "--verbose", "--debug", "--show-log",
 		"--logging-config=juju.cmd=INFO;juju.worker.deployer=DEBUG")
 	c.Assert(log.Path, gc.Equals, "foo")
 	c.Assert(log.Verbose, gc.Equals, true)
 	c.Assert(log.Debug, gc.Equals, true)
+	c.Assert(log.ShowLog, gc.Equals, true)
 	c.Assert(log.Config, gc.Equals, "juju.cmd=INFO;juju.worker.deployer=DEBUG")
 }
 

--- a/output_test.go
+++ b/output_test.go
@@ -5,6 +5,8 @@ package cmd_test
 
 import (
 	"github.com/juju/gnuflag"
+	"github.com/juju/loggo"
+	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 
 	"github.com/juju/cmd/v3"
@@ -133,44 +135,68 @@ var outputTests = map[string][]struct {
 	},
 }
 
-func (s *CmdSuite) TestOutputFormat(c *gc.C) {
-	for format, tests := range outputTests {
-		c.Logf("format %s", format)
-		var args []string
-		if format != "" {
-			args = []string{"--format", format}
-		}
-		for i, t := range tests {
-			c.Logf("  test %d", i)
-			ctx := cmdtesting.Context(c)
-			result := cmd.Main(&OutputCommand{value: t.value}, ctx, args)
-			c.Check(result, gc.Equals, 0)
-			c.Check(bufferString(ctx.Stdout), gc.Equals, t.output)
-			c.Check(bufferString(ctx.Stderr), gc.Equals, "")
-		}
+type OutputSuite struct {
+	testing.LoggingCleanupSuite
+
+	ctx *cmd.Context
+}
+
+var _ = gc.Suite(&OutputSuite{})
+
+func (s *OutputSuite) SetUpTest(c *gc.C) {
+	s.LoggingCleanupSuite.SetUpTest(c)
+	s.ctx = cmdtesting.Context(c)
+	loggo.ReplaceDefaultWriter(cmd.NewWarningWriter(s.ctx.Stderr))
+}
+
+func (s *OutputSuite) TestOutputFormat(c *gc.C) {
+	s.testOutputFormat(c, "")
+}
+func (s *OutputSuite) TestOutputFormatSmart(c *gc.C) {
+	s.testOutputFormat(c, "smart")
+}
+func (s *OutputSuite) TestOutputFormatJson(c *gc.C) {
+	s.testOutputFormat(c, "json")
+}
+func (s *OutputSuite) TestOutputFormatYaml(c *gc.C) {
+	s.testOutputFormat(c, "yaml")
+}
+
+func (s *OutputSuite) testOutputFormat(c *gc.C, format string) {
+	tests := outputTests[format]
+	var args []string
+	if format != "" {
+		args = []string{"--format", format}
+	}
+	for i, t := range tests {
+		c.Logf("  test %d", i)
+		s.SetUpTest(c)
+		result := cmd.Main(&OutputCommand{value: t.value}, s.ctx, args)
+		c.Check(result, gc.Equals, 0)
+		c.Check(bufferString(s.ctx.Stdout), gc.Equals, t.output)
+		c.Check(bufferString(s.ctx.Stderr), gc.Equals, "")
+		s.TearDownTest(c)
 	}
 }
 
-func (s *CmdSuite) TestUnknownOutputFormat(c *gc.C) {
-	ctx := cmdtesting.Context(c)
-	result := cmd.Main(&OutputCommand{}, ctx, []string{"--format", "cuneiform"})
+func (s *OutputSuite) TestUnknownOutputFormat(c *gc.C) {
+	result := cmd.Main(&OutputCommand{}, s.ctx, []string{"--format", "cuneiform"})
 	c.Check(result, gc.Equals, 2)
-	c.Check(bufferString(ctx.Stderr), gc.Equals, "")
-	c.Check(c.GetTestLog(), gc.Matches, ".*: unknown format \"cuneiform\"\n")
+	c.Check(bufferString(s.ctx.Stdout), gc.Equals, "")
+	c.Check(bufferString(s.ctx.Stderr), gc.Matches, ".*: unknown format \"cuneiform\"\n")
 }
 
 // Py juju allowed both --format json and --format=json. This test verifies that juju is
 // being built against a version of the gnuflag library (rev 14 or above) that supports
 // this argument format.
 // LP #1059921
-func (s *CmdSuite) TestFormatAlternativeSyntax(c *gc.C) {
-	ctx := cmdtesting.Context(c)
-	result := cmd.Main(&OutputCommand{}, ctx, []string{"--format=json"})
+func (s *OutputSuite) TestFormatAlternativeSyntax(c *gc.C) {
+	result := cmd.Main(&OutputCommand{}, s.ctx, []string{"--format=json"})
 	c.Assert(result, gc.Equals, 0)
-	c.Assert(bufferString(ctx.Stdout), gc.Equals, "null\n")
+	c.Assert(bufferString(s.ctx.Stdout), gc.Equals, "null\n")
 }
 
-func (s *CmdSuite) TestFormatters(c *gc.C) {
+func (s *OutputSuite) TestFormatters(c *gc.C) {
 	typeFormatters := cmd.DefaultFormatters
 	formatters := typeFormatters.Formatters()
 

--- a/supercommand.go
+++ b/supercommand.go
@@ -533,7 +533,7 @@ func (c *SuperCommand) Run(ctx *Context) error {
 			return handleErr
 		}
 
-		WriteError(ctx.Stderr, err)
+		ctx.Errorf("%s", err)
 		logger.Debugf("error stack: \n%v", errors.ErrorStack(err))
 
 		// Err has been logged above, we can make the err silent so it does not log again in cmd/main


### PR DESCRIPTION
Also swap out some WriteError with Errorf

Do this instead of looking in GetTestLog. This is less invasive, and more readable

This did require creating context in SetUp and storing in the suite, which is a little fiddly with some tests which loop over test sub case, or tests which clear stdout/err buffers

## QA Steps

Unit tests run successfully