### PR TITLE
Revert to WriteError

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -388,7 +388,7 @@ func handleCommandError(c Command, ctx *Context, err error, f *gnuflag.FlagSet) 
 	case ErrSilent:
 		return 2, true
 	default:
-		ctx.Errorf("%s", err)
+		WriteError(ctx.Stderr, err)
 		return 2, true
 	}
 }
@@ -421,7 +421,7 @@ func Main(c Command, ctx *Context, args []string) int {
 			return err.(*RcPassthroughError).Code
 		}
 		if err != ErrSilent {
-			ctx.Errorf("%s", err)
+			WriteError(ctx.Stderr, err)
 		}
 		return 1
 	}

--- a/cmdtesting/cmd.go
+++ b/cmdtesting/cmd.go
@@ -89,7 +89,7 @@ func RunCommandInDir(c *gc.C, com cmd.Command, args []string, dir string) (*cmd.
 
 func runCommand(ctx *cmd.Context, com cmd.Command, args []string) (*cmd.Context, error) {
 	if err := InitCommand(com, args); err != nil {
-		ctx.Errorf("%s", err)
+		cmd.WriteError(ctx.Stderr, err)
 		return ctx, err
 	}
 	return ctx, com.Run(ctx)

--- a/supercommand.go
+++ b/supercommand.go
@@ -544,7 +544,7 @@ func (c *SuperCommand) Run(ctx *Context) error {
 			return handleErr
 		}
 
-		ctx.Errorf("%s", err)
+		WriteError(ctx.Stderr, err)
 		logger.Debugf("error stack: \n%v", errors.ErrorStack(err))
 
 		// Err has been logged above, we can make the err silent so it does not log again in cmd/main

--- a/supercommand_test.go
+++ b/supercommand_test.go
@@ -283,7 +283,7 @@ func (s *SuperCommandSuite) TestLogging(c *gc.C) {
 	sc.Register(&TestCommand{Name: "blah"})
 	code := cmd.Main(sc, s.ctx, []string{"blah", "--option", "error", "--debug"})
 	c.Assert(code, gc.Equals, 1)
-	c.Assert(cmdtesting.Stderr(s.ctx), gc.Matches, `(?m).* ERROR .* BAM!\n.* DEBUG .* error stack: \n.*`)
+	c.Assert(cmdtesting.Stderr(s.ctx), gc.Matches, `(?m)ERROR BAM!\n.* DEBUG .* error stack: \n.*`)
 }
 
 type notifyTest struct {


### PR DESCRIPTION
Currently using ctx.Errorf in these places causes failures in juju testing because of the way our testing suites handle logging and streams