### PR TITLE
[JUJU-3454] Print examples in help

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -372,7 +372,7 @@ func (i *Info) HelpWithSuperFlags(superF *gnuflag.FlagSet, f *gnuflag.FlagSet) [
 		fmt.Fprintf(buf, "\nAliases: %s\n", strings.Join(i.Aliases, ", "))
 	}
 	if len(i.Examples) > 0 {
-		fmt.Fprintf(buf, "\nExamples:\n%s\n", i.Examples)
+		fmt.Fprintf(buf, "\nExamples:\n%s", i.Examples)
 	}
 
 	return buf.Bytes()

--- a/cmd.go
+++ b/cmd.go
@@ -371,6 +371,10 @@ func (i *Info) HelpWithSuperFlags(superF *gnuflag.FlagSet, f *gnuflag.FlagSet) [
 	if len(i.Aliases) > 0 {
 		fmt.Fprintf(buf, "\nAliases: %s\n", strings.Join(i.Aliases, ", "))
 	}
+	if len(i.Examples) > 0 {
+		fmt.Fprintf(buf, "\nExamples:\n%s\n", i.Examples)
+	}
+
 	return buf.Bytes()
 }
 


### PR DESCRIPTION
Print the examples field from `Info` in the generic help command.