### PR TITLE
[JUJU-3482] Prepopulate ids for command references on discourse

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -374,6 +374,9 @@ func (i *Info) HelpWithSuperFlags(superF *gnuflag.FlagSet, f *gnuflag.FlagSet) [
 	if len(i.Examples) > 0 {
 		fmt.Fprintf(buf, "\nExamples:\n%s", i.Examples)
 	}
+	if len(i.SeeAlso) > 0 {
+		fmt.Fprintf(buf, "\nSee also:\n%s", strings.Join(i.SeeAlso, "\n"))
+	}
 
 	return buf.Bytes()
 }


### PR DESCRIPTION
Some context about this PR. 

In [this juju PR](https://github.com/juju/juju/pull/15406) we are preparing the `juju documentation` output to be published on discourse as part of our GitHub actions. Discourse does not permit to set the topic url. This means that any published post will have a topic id. This means that the `See Also` section has to look like

```md
## See also
- [add-secret-backend](/t/8695)
- [remove-secret-backend](/t/8700)
- [show-secret-backend](/t/8698)
- [update-secret-backend](/t/8699)
```
where the ids are passed to the `documentation` command using the `--discourse-ids <file-path>` commands.  During the rendering process, the target command will be replaced with `/t/id`. Additional code is added to support situations where the entries in the `SeeAlso` section use aliases instead of the original commands.
