### PR TITLE
[docs] escape special chars in Markdown

### DIFF
--- a/documentation_test.go
+++ b/documentation_test.go
@@ -39,7 +39,7 @@ func (s *documentationSuite) TestFormatCommand(c *gc.C) {
 summary for add-cloud...
 
 ## Usage
-` + "```" + `juju [options] <cloud name> [<cloud definition file>]` + "```" + `
+` + "```" + `juju add-cloud [options] <cloud name> [<cloud definition file>]` + "```" + `
 
 ### Options
 | Flag | Default | Usage |
@@ -65,9 +65,6 @@ details for add-cloud...
 			&cmd.SuperCommand{Name: "juju"},
 			t.title,
 		)
-		fmt.Println("------------")
-		fmt.Println(output)
-		fmt.Println("------------")
 		c.Check(output, gc.Equals, t.expected)
 	}
 }
@@ -95,3 +92,74 @@ func (c *docTestCommand) IsSuperCommand() bool         { return false }
 func (c *docTestCommand) Init(args []string) error     { return nil }
 func (c *docTestCommand) Run(ctx *cmd.Context) error   { return nil }
 func (c *docTestCommand) AllowInterspersedFlags() bool { return false }
+
+func (*documentationSuite) TestEscapeMarkdown(c *gc.C) {
+	tests := []struct {
+		input, output string
+	}{{
+		input: `
+Juju needs to know how to connect to clouds. A cloud definition 
+describes a cloud's endpoints and authentication requirements. Each
+definition is stored and accessed later as <cloud name>.
+
+If you are accessing a public cloud, running add-cloud is unlikely to be 
+necessary.  Juju already contains definitions for the public cloud 
+providers it supports.
+
+add-cloud operates in two modes:
+
+    juju add-cloud
+    juju add-cloud <cloud name> <cloud definition file>
+`,
+		output: `
+Juju needs to know how to connect to clouds. A cloud definition 
+describes a cloud's endpoints and authentication requirements. Each
+definition is stored and accessed later as &lt;cloud name&gt;.
+
+If you are accessing a public cloud, running add-cloud is unlikely to be 
+necessary.  Juju already contains definitions for the public cloud 
+providers it supports.
+
+add-cloud operates in two modes:
+
+    juju add-cloud
+    juju add-cloud <cloud name> <cloud definition file>
+`,
+	}, {
+		input:  "Specify output format (default|json|tabular|yaml)",
+		output: "Specify output format (default&#x7c;json&#x7c;tabular&#x7c;yaml)",
+	}, {
+		input:  "Model to operate in. Accepts [<controller name>:]<model name>|<model UUID>",
+		output: "Model to operate in. Accepts [&lt;controller name&gt;:]&lt;model name&gt;&#x7c;&lt;model UUID&gt;",
+	}, {
+		input:  "The following characters are inside a code span, so they shouldn't be escaped: `< > | &`",
+		output: "The following characters are inside a code span, so they shouldn't be escaped: `< > | &`",
+	}, {
+		input: `
+The juju add-credential command operates in two modes.
+
+When called with only the <cloud name> argument, ` + "`" + `juju add-credential` + "`" + ` will 
+take you through an interactive prompt to add a credential specific to 
+the cloud provider.
+
+Providing the ` + "`" + `-f <credentials.yaml>` + "`" + ` option switches to the 
+non-interactive mode. <credentials.yaml> must be a path to a correctly 
+formatted YAML-formatted file.
+`,
+		output: `
+The juju add-credential command operates in two modes.
+
+When called with only the &lt;cloud name&gt; argument, ` + "`" + `juju add-credential` + "`" + ` will 
+take you through an interactive prompt to add a credential specific to 
+the cloud provider.
+
+Providing the ` + "`" + `-f <credentials.yaml>` + "`" + ` option switches to the 
+non-interactive mode. &lt;credentials.yaml&gt; must be a path to a correctly 
+formatted YAML-formatted file.
+`,
+	}}
+
+	for _, t := range tests {
+		c.Check(cmd.EscapeMarkdown(t.input), gc.Equals, t.output)
+	}
+}


### PR DESCRIPTION
Escape special characters (so far, `<`, `>`, `&`, `|`) in Markdown output (except inside code blocks), so the resulting Markdown document displays better.

Somehow we lost the command name in the rendered output too - so instead of 
```
juju add-credential [options] <cloud name>
```
it displays as
```
juju [options] <cloud name>
```

Add this back in.

## QA

See the results [here](https://discourse.charmhub.io/t/juju-cli-commands/10513)