### PR TITLE
Add missing end of line after See Also section in help.

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -375,11 +375,10 @@ func (i *Info) HelpWithSuperFlags(superF *gnuflag.FlagSet, f *gnuflag.FlagSet) [
 		fmt.Fprintf(buf, "\nExamples:\n%s", i.Examples)
 	}
 	if len(i.SeeAlso) > 0 {
-		prettySeeAlso := ""
+		fmt.Fprintf(buf, "\nSee also:\n")
 		for _, entry := range i.SeeAlso {
-			prettySeeAlso = prettySeeAlso + fmt.Sprintf(" - %s\n", entry)
+			fmt.Fprintf(buf, " - %s\n", entry)
 		}
-		fmt.Fprintf(buf, "\nSee also:\n%s\n", prettySeeAlso)
 	}
 
 	return buf.Bytes()


### PR DESCRIPTION
Add a missing end of line when printing help after the `See Also` section.

```bash
juju help add-k8s
Usage: juju run [options] <unit> [<unit> ...] <action-name> [<key>=<value> [<key>[.<key> ...]=<value>]]

Summary:
Run an action on a specified unit.

.....
    juju run mysql/3 backup --params parameters.yml
    juju run mysql/3 backup out=out.tar.bz2 file.kind=xz file.quality=high
    juju run mysql/3 backup --params p.yml file.kind=xz file.quality=high
    juju run sleeper/0 pause time=1000
    juju run sleeper/0 pause --string-args time=1000

See also:
 - operations
 - show-operation
 - show-task
```