### PR TITLE
Allow hiding of supercommand documentation

### DIFF
--- a/documentation.go
+++ b/documentation.go
@@ -205,7 +205,7 @@ func (c *documentationCommand) writeDocs(folder string, superCommands []string, 
 		commandSeq := append(superCommands, name)
 
 		sc, isSuperCommand := ref.command.(*SuperCommand)
-		if !isSuperCommand || (isSuperCommand && !sc.FlagDocumentationHidden) {
+		if !isSuperCommand || (isSuperCommand && !sc.SkipCommandDoc) {
 			target := fmt.Sprintf("%s.md", strings.Join(commandSeq[1:], "_"))
 			target = strings.ReplaceAll(target, " ", "_")
 			target = filepath.Join(folder, target)
@@ -283,7 +283,7 @@ func (c *documentationCommand) writeSections(w io.Writer, superCommands []string
 		commandSeq := append(superCommands, name)
 
 		sc, isSuperCommand := ref.command.(*SuperCommand)
-		if !isSuperCommand || (isSuperCommand && !sc.FlagDocumentationHidden) {
+		if !isSuperCommand || (isSuperCommand && !sc.SkipCommandDoc) {
 			_, err := fmt.Fprintf(w, "%s", c.formatCommand(ref, true, commandSeq))
 			if err != nil {
 				return err

--- a/supercommand.go
+++ b/supercommand.go
@@ -101,8 +101,16 @@ type SuperCommandParams struct {
 	// will use that name when referring to an individual items/flags in this command.
 	// For example, if this value is 'option', the default message 'value for flag'
 	// will become 'value for option'.
-	FlagKnownAs             string
-	FlagDocumentationHidden bool
+	FlagKnownAs string
+
+	// SkipCommandDoc is used to skip over the super command documentation.
+	// This is useful when the super command is used as a wrapper for other
+	// commands, and the documentation is not relevant to the output of the
+	// documentation.
+	// TODO (stickupkid): Remove this. This shouldn't be here, but the
+	// documentation command is at the wrong abstraction, so we need to
+	// hack around it.
+	SkipCommandDoc bool
 }
 
 // FlagAdder represents a value that has associated flags.
@@ -122,16 +130,16 @@ func NewSuperCommand(params SuperCommandParams) *SuperCommand {
 		Log:      params.Log,
 		Aliases:  params.Aliases,
 
-		globalFlags:             params.GlobalFlags,
-		usagePrefix:             params.UsagePrefix,
-		missingCallback:         params.MissingCallback,
-		version:                 params.Version,
-		versionDetail:           params.VersionDetail,
-		notifyRun:               params.NotifyRun,
-		notifyHelp:              params.NotifyHelp,
-		userAliasesFilename:     params.UserAliasesFilename,
-		FlagKnownAs:             params.FlagKnownAs,
-		FlagDocumentationHidden: params.FlagDocumentationHidden,
+		globalFlags:         params.GlobalFlags,
+		usagePrefix:         params.UsagePrefix,
+		missingCallback:     params.MissingCallback,
+		version:             params.Version,
+		versionDetail:       params.VersionDetail,
+		notifyRun:           params.NotifyRun,
+		notifyHelp:          params.NotifyHelp,
+		userAliasesFilename: params.UserAliasesFilename,
+		FlagKnownAs:         params.FlagKnownAs,
+		SkipCommandDoc:      params.SkipCommandDoc,
 	}
 	command.init()
 	return command
@@ -194,8 +202,16 @@ type SuperCommand struct {
 	// will use that name when referring to an individual items/flags in this command.
 	// For example, if this value is 'option', the default message 'value for flag'
 	// will become 'value for option'.
-	FlagKnownAs             string
-	FlagDocumentationHidden bool
+	FlagKnownAs string
+
+	// SkipCommandDoc is used to skip over the super command documentation.
+	// This is useful when the super command is used as a wrapper for other
+	// commands, and the documentation is not relevant to the output of the
+	// documentation.
+	// TODO (stickupkid): Remove this. This shouldn't be here, but the
+	// documentation command is at the wrong abstraction, so we need to
+	// hack around it.
+	SkipCommandDoc bool
 }
 
 // IsSuperCommand implements Command.IsSuperCommand

--- a/supercommand.go
+++ b/supercommand.go
@@ -101,7 +101,8 @@ type SuperCommandParams struct {
 	// will use that name when referring to an individual items/flags in this command.
 	// For example, if this value is 'option', the default message 'value for flag'
 	// will become 'value for option'.
-	FlagKnownAs string
+	FlagKnownAs             string
+	FlagDocumentationHidden bool
 }
 
 // FlagAdder represents a value that has associated flags.
@@ -121,15 +122,16 @@ func NewSuperCommand(params SuperCommandParams) *SuperCommand {
 		Log:      params.Log,
 		Aliases:  params.Aliases,
 
-		globalFlags:         params.GlobalFlags,
-		usagePrefix:         params.UsagePrefix,
-		missingCallback:     params.MissingCallback,
-		version:             params.Version,
-		versionDetail:       params.VersionDetail,
-		notifyRun:           params.NotifyRun,
-		notifyHelp:          params.NotifyHelp,
-		userAliasesFilename: params.UserAliasesFilename,
-		FlagKnownAs:         params.FlagKnownAs,
+		globalFlags:             params.GlobalFlags,
+		usagePrefix:             params.UsagePrefix,
+		missingCallback:         params.MissingCallback,
+		version:                 params.Version,
+		versionDetail:           params.VersionDetail,
+		notifyRun:               params.NotifyRun,
+		notifyHelp:              params.NotifyHelp,
+		userAliasesFilename:     params.UserAliasesFilename,
+		FlagKnownAs:             params.FlagKnownAs,
+		FlagDocumentationHidden: params.FlagDocumentationHidden,
 	}
 	command.init()
 	return command
@@ -192,7 +194,8 @@ type SuperCommand struct {
 	// will use that name when referring to an individual items/flags in this command.
 	// For example, if this value is 'option', the default message 'value for flag'
 	// will become 'value for option'.
-	FlagKnownAs string
+	FlagKnownAs             string
+	FlagDocumentationHidden bool
 }
 
 // IsSuperCommand implements Command.IsSuperCommand
@@ -218,8 +221,10 @@ func (c *SuperCommand) init() {
 	}
 	c.subcmds = map[string]commandReference{
 		"help": {command: c.help},
-		"documentation": {command: c.documentation,
-			name: "documentation"},
+		"documentation": {
+			command: c.documentation,
+			name:    "documentation",
+		},
 	}
 
 	if c.version != "" {


### PR DESCRIPTION
The following allows the hiding of the supercommand documentation. It's not always required to show the supercommand documentation. Most supercommands (wait-for, jujud, container-agent) don't always give you anything of any importance or worthwhile.

To enable that, we just add a new flag on the supercommand to skip it during documentation output.

This is the fix for https://github.com/juju/cmd/issues/100
