### PR TITLE
Fix Markdown output of `documentation` command

### DIFF
--- a/documentation.go
+++ b/documentation.go
@@ -501,7 +501,9 @@ func (d *documentationCommand) formatFlags(c Command, info *Info) string {
 			theFlags += fmt.Sprintf("`--%s`", f.Name)
 		}
 		formatted += fmt.Sprintf("| %s | %s | %s |\n", theFlags,
-			EscapeMarkdown(fs[0].DefValue), EscapeMarkdown(fs[0].Usage))
+			EscapeMarkdown(fs[0].DefValue),
+			strings.ReplaceAll(EscapeMarkdown(fs[0].Usage), "\n", " "),
+		)
 	}
 	return formatted
 }


### PR DESCRIPTION
- If a flag's description/usage spans multiple lines, the Markdown will not display properly when this is placed inside a table (e.g. [here](https://discourse.charmhub.io/t/command-bootstrap/10132)). Fix this by replacing newlines with spaces to put this on a single line.