### PR TITLE
chore: Merge v3 to v4

### DIFF
--- a/documentation.go
+++ b/documentation.go
@@ -501,7 +501,9 @@ func (d *documentationCommand) formatFlags(c Command, info *Info) string {
 			theFlags += fmt.Sprintf("`--%s`", f.Name)
 		}
 		formatted += fmt.Sprintf("| %s | %s | %s |\n", theFlags,
-			EscapeMarkdown(fs[0].DefValue), EscapeMarkdown(fs[0].Usage))
+			EscapeMarkdown(fs[0].DefValue),
+			strings.ReplaceAll(EscapeMarkdown(fs[0].Usage), "\n", " "),
+		)
 	}
 	return formatted
 }

--- a/documentation_test.go
+++ b/documentation_test.go
@@ -30,7 +30,7 @@ func (s *documentationSuite) TestFormatCommand(c *gc.C) {
 				SeeAlso:  []string{"clouds", "update-cloud", "remove-cloud", "update-credential"},
 				Aliases:  []string{"cloud-add", "import-cloud"},
 			},
-			flags: []string{"force", "format", "output"},
+			flags: []testFlag{{name: "force", short: "f"}, {name: "format" /* no short flag */}, {name: "output", short: "o"}},
 		},
 		title: false,
 		expected: (`
@@ -45,9 +45,9 @@ summary for add-cloud...
 ### Options
 | Flag | Default | Usage |
 | --- | --- | --- |
-| ` + "`" + `--force` + "`" + ` | default value for "force" flag | description for "force" flag |
+| ` + "`" + `-f` + "`" + `, ` + "`" + `--force` + "`" + ` | default value for "force" flag | description for "force" flag |
 | ` + "`" + `--format` + "`" + ` | default value for "format" flag | description for "format" flag |
-| ` + "`" + `--output` + "`" + ` | default value for "output" flag | description for "output" flag |
+| ` + "`" + `-o` + "`" + `, ` + "`" + `--output` + "`" + ` | default value for "output" flag | description for "output" flag |
 
 ## Examples
 examples for add-cloud...
@@ -68,7 +68,7 @@ details for add-cloud...
 				Doc:      "insert details here...",
 				Examples: "insert examples here...",
 			},
-			flags: []string{},
+			flags: []testFlag{},
 		},
 		title: false,
 		expected: (`
@@ -105,7 +105,13 @@ insert details here...
 // documentation output.
 type docTestCommand struct {
 	info  *cmd.Info
-	flags []string
+	flags []testFlag
+}
+
+// testFlag is a definition for flag in test. It allows to provide an optional short name for the flag
+type testFlag struct {
+	name  string
+	short string // optional
 }
 
 func (c *docTestCommand) Info() *cmd.Info {
@@ -114,9 +120,17 @@ func (c *docTestCommand) Info() *cmd.Info {
 
 func (c *docTestCommand) SetFlags(f *gnuflag.FlagSet) {
 	for _, flag := range c.flags {
-		f.String(flag,
-			fmt.Sprintf("default value for %q flag", flag),
-			fmt.Sprintf("description for %q flag", flag))
+		var fakeValue string
+		defaultValue := fmt.Sprintf("default value for %q flag", flag.name)
+		description := fmt.Sprintf("description for %q flag", flag.name)
+		f.StringVar(&fakeValue, flag.name,
+			defaultValue,
+			description)
+		if flag.short != "" {
+			f.StringVar(&fakeValue, flag.short,
+				defaultValue,
+				description)
+		}
 	}
 }
 

--- a/supercommand.go
+++ b/supercommand.go
@@ -102,6 +102,15 @@ type SuperCommandParams struct {
 	// For example, if this value is 'option', the default message 'value for flag'
 	// will become 'value for option'.
 	FlagKnownAs string
+
+	// SkipCommandDoc is used to skip over the super command documentation.
+	// This is useful when the super command is used as a wrapper for other
+	// commands, and the documentation is not relevant to the output of the
+	// documentation.
+	// TODO (stickupkid): Remove this. This shouldn't be here, but the
+	// documentation command is at the wrong abstraction, so we need to
+	// hack around it.
+	SkipCommandDoc bool
 }
 
 // FlagAdder represents a value that has associated flags.
@@ -130,6 +139,7 @@ func NewSuperCommand(params SuperCommandParams) *SuperCommand {
 		notifyHelp:          params.NotifyHelp,
 		userAliasesFilename: params.UserAliasesFilename,
 		FlagKnownAs:         params.FlagKnownAs,
+		SkipCommandDoc:      params.SkipCommandDoc,
 	}
 	command.init()
 	return command
@@ -193,6 +203,15 @@ type SuperCommand struct {
 	// For example, if this value is 'option', the default message 'value for flag'
 	// will become 'value for option'.
 	FlagKnownAs string
+
+	// SkipCommandDoc is used to skip over the super command documentation.
+	// This is useful when the super command is used as a wrapper for other
+	// commands, and the documentation is not relevant to the output of the
+	// documentation.
+	// TODO (stickupkid): Remove this. This shouldn't be here, but the
+	// documentation command is at the wrong abstraction, so we need to
+	// hack around it.
+	SkipCommandDoc bool
 }
 
 // IsSuperCommand implements Command.IsSuperCommand
@@ -218,8 +237,10 @@ func (c *SuperCommand) init() {
 	}
 	c.subcmds = map[string]commandReference{
 		"help": {command: c.help},
-		"documentation": {command: c.documentation,
-			name: "documentation"},
+		"documentation": {
+			command: c.documentation,
+			name:    "documentation",
+		},
 	}
 
 	if c.version != "" {


### PR DESCRIPTION
Merge forward v3 to v4 to fix the flag generation issue (monocharacter flags where prefixed by two dashes instead of one)