### PR TITLE
feat: exported PrintMarkdown function

### DIFF
--- a/cmdtesting/cmd.go
+++ b/cmdtesting/cmd.go
@@ -43,7 +43,7 @@ func Context(c *gc.C) *cmd.Context {
 		Stdout: &bytes.Buffer{},
 		Stderr: &bytes.Buffer{},
 	}
-	ctx.Context = context.TODO()
+	ctx.Context = context.Background()
 	return ctx
 }
 

--- a/documentation_test.go
+++ b/documentation_test.go
@@ -38,6 +38,8 @@ func (s *documentationSuite) TestFormatCommand(c *gc.C) {
 		expected: (`
 > See also: [clouds](#clouds), [update-cloud](#update-cloud), [remove-cloud](#remove-cloud), [update-credential](#update-credential)
 
+**Aliases:** cloud-add, import-cloud
+
 ## Summary
 summary for add-cloud...
 
@@ -57,8 +59,6 @@ examples for add-cloud...
 ## Details
 details for add-cloud...
 
----
-
 `)[1:],
 	}, {
 		// no flags - don't print "Options" table
@@ -74,7 +74,6 @@ details for add-cloud...
 		},
 		title: false,
 		expected: (`
-
 ## Summary
 insert summary here...
 
@@ -86,8 +85,6 @@ insert examples here...
 
 ## Details
 insert details here...
-
----
 
 `)[1:],
 	}}

--- a/markdown.go
+++ b/markdown.go
@@ -1,0 +1,322 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/juju/gnuflag"
+)
+
+// InfoCommand is a subset of Command methods needed to print the Markdown
+// document. In particular, all these methods are "static", hence should not
+// do anything scary or destructive.
+type InfoCommand interface {
+	// Info returns information about the Command.
+	Info() *Info
+	// SetFlags adds command specific flags to the flag set.
+	SetFlags(f *gnuflag.FlagSet)
+}
+
+// MarkdownOptions configures the output of the PrintMarkdown function.
+type MarkdownOptions struct {
+	// Title defines the title to print at the top of the document. If this
+	// field is empty, no title will be printed.
+	Title string
+	// UsagePrefix will be printed before the command usage (for example, the
+	// name of the supercommand).
+	UsagePrefix string
+	// LinkForCommand maps each "peer command" name (e.g. see also commands) to
+	// the link target for that command (e.g. a section of the Markdown doc, or
+	// a webpage).
+	LinkForCommand func(string) string
+	// LinkForSubcommand maps each sub-command name to the link target for that
+	//command (e.g. a section of the Markdown doc, or a webpage).
+	LinkForSubcommand func(string) string
+}
+
+// PrintMarkdown prints Markdown documentation about the given command to the
+// given io.Writer. The MarkdownOptions can be provided to customise the
+// output.
+func PrintMarkdown(w io.Writer, cmd InfoCommand, opts MarkdownOptions) error {
+	// We will write the document to a bytes.Buffer, then copy it over to the
+	// specified io.Writer. This saves us having to check errors on every
+	// single write - we can just check at the end when we copy over.
+	var doc bytes.Buffer
+
+	if opts.Title != "" {
+		fmt.Fprintf(&doc, "# %s\n\n", opts.Title)
+	}
+
+	info := cmd.Info()
+
+	// See Also
+	if len(info.SeeAlso) > 0 {
+		printSeeAlso(&doc, info.SeeAlso, opts.LinkForCommand)
+	}
+
+	if len(info.Aliases) > 0 {
+		fmt.Fprint(&doc, "**Aliases:** ")
+		fmt.Fprint(&doc, strings.Join(info.Aliases, ", "))
+		fmt.Fprintln(&doc)
+		fmt.Fprintln(&doc)
+	}
+
+	// Summary
+	fmt.Fprintln(&doc, "## Summary")
+	fmt.Fprintln(&doc, info.Purpose)
+	fmt.Fprintln(&doc)
+
+	// Usage
+	if strings.TrimSpace(info.Args) != "" {
+		fmt.Fprintln(&doc, "## Usage")
+		fmt.Fprintf(&doc, "```")
+		fmt.Fprint(&doc, opts.UsagePrefix)
+		fmt.Fprintf(&doc, "%s [%ss] %s", info.Name, getFlagsName(info.FlagKnownAs), info.Args)
+		fmt.Fprintf(&doc, "```")
+		fmt.Fprintln(&doc)
+		fmt.Fprintln(&doc)
+	}
+
+	// Options
+	printFlags(&doc, cmd)
+
+	// Examples
+	if info.Examples != "" {
+		fmt.Fprintln(&doc, "## Examples")
+		fmt.Fprintln(&doc, info.Examples)
+		fmt.Fprintln(&doc)
+	}
+
+	// Details
+	if info.Doc != "" {
+		fmt.Fprintln(&doc, "## Details")
+		fmt.Fprintln(&doc, EscapeMarkdown(info.Doc))
+		fmt.Fprintln(&doc)
+	}
+
+	if len(info.Subcommands) > 0 {
+		printSubcommands(&doc, info.Subcommands, opts.LinkForSubcommand)
+	}
+
+	_, err := io.Copy(w, &doc)
+	if err != nil {
+		return fmt.Errorf("writing Markdown: %w", err)
+	}
+	return nil
+}
+
+func printSeeAlso(
+	w io.Writer,
+	seeAlso []string,
+	linkForCommand func(string) string,
+) {
+	fmt.Fprint(w, "> See also: ")
+
+	for i, cmdName := range seeAlso {
+		fmt.Fprint(w, markdownLink(cmdName, linkForCommand))
+
+		// Separate command names by commas
+		if i < len(seeAlso)-1 {
+			fmt.Fprint(w, ", ")
+		}
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintln(w)
+}
+
+// getFlagsName returns the default name for a command's flags, if this is not
+// defined in the info.
+func getFlagsName(fka string) string {
+	if fka == "" {
+		return "option"
+	}
+	return fka
+}
+
+func printFlags(w io.Writer, cmd InfoCommand) {
+	info := cmd.Info()
+
+	flagKnownAs := getFlagsName(info.FlagKnownAs)
+	f := gnuflag.NewFlagSetWithFlagKnownAs(info.Name, gnuflag.ContinueOnError, flagKnownAs)
+	cmd.SetFlags(f)
+
+	// group together all flags for a given value, meaning that flag which sets the same value are
+	// grouped together and displayed with the same description, as below:
+	//
+	// -s, --short, --alternate-string | default value | some description.
+	flags := make(map[interface{}]flagsByLength)
+	f.VisitAll(func(f *gnuflag.Flag) {
+		flags[f.Value] = append(flags[f.Value], f)
+	})
+	if len(flags) == 0 {
+		// No flags, so we won't print this section
+		return
+	}
+
+	// sort the output flags by shortest name for each group.
+	// Caution: this mean that description/default value displayed in documentation will
+	// be the one of the shortest alias. Other will be discarded. Be careful to have the same default
+	// values between each alias, and put the description on the shortest alias.
+	var byName flagsByName
+	for _, fl := range flags {
+		sort.Sort(fl)
+		byName = append(byName, fl)
+	}
+	sort.Sort(byName)
+
+	fmt.Fprintln(w, "### Options")
+	fmt.Fprintln(w, "| Flag | Default | Usage |")
+	fmt.Fprintln(w, "| --- | --- | --- |")
+
+	for _, fs := range byName {
+		// Collect all flag aliases (usually a short one and a plain one, like -v / --verbose)
+		formattedFlags := ""
+		for i, f := range fs {
+			if i > 0 {
+				formattedFlags += ", "
+			}
+			if len(f.Name) == 1 {
+				formattedFlags += fmt.Sprintf("`-%s`", f.Name)
+			} else {
+				formattedFlags += fmt.Sprintf("`--%s`", f.Name)
+			}
+		}
+		// display all the flags aliases and the default value and description of the shortest one.
+		// Escape Markdown in description in order to display it cleanly in the final documentation.
+		fmt.Fprintf(w, "| %s | %s | %s |\n", formattedFlags,
+			EscapeMarkdown(fs[0].DefValue),
+			strings.ReplaceAll(EscapeMarkdown(fs[0].Usage), "\n", " "),
+		)
+	}
+	fmt.Fprintln(w)
+}
+
+// flagsByLength is a slice of flags implementing sort.Interface,
+// sorting primarily by the length of the flag, and secondarily
+// alphabetically.
+type flagsByLength []*gnuflag.Flag
+
+func (f flagsByLength) Less(i, j int) bool {
+	s1, s2 := f[i].Name, f[j].Name
+	if len(s1) != len(s2) {
+		return len(s1) < len(s2)
+	}
+	return s1 < s2
+}
+func (f flagsByLength) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+func (f flagsByLength) Len() int {
+	return len(f)
+}
+
+// flagsByName is a slice of slices of flags implementing sort.Interface,
+// alphabetically sorting by the name of the first flag in each slice.
+type flagsByName [][]*gnuflag.Flag
+
+func (f flagsByName) Less(i, j int) bool {
+	return f[i][0].Name < f[j][0].Name
+}
+func (f flagsByName) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+func (f flagsByName) Len() int {
+	return len(f)
+}
+
+func printSubcommands(
+	w io.Writer,
+	subcommands map[string]string,
+	linkForSubcommand func(string) string,
+) {
+	sorted := []string{}
+	for name := range subcommands {
+		if isDefaultCommand(name) {
+			continue
+		}
+		sorted = append(sorted, name)
+	}
+	sort.Strings(sorted)
+
+	if len(sorted) > 0 {
+		fmt.Fprintln(w, "## Subcommands")
+		for _, name := range sorted {
+			fmt.Fprint(w, "- ")
+			fmt.Fprint(w, markdownLink(name, linkForSubcommand))
+			fmt.Fprintln(w)
+		}
+		fmt.Fprintln(w)
+	}
+}
+
+// markdownLink uses the provided linker function to generate a Markdown
+// hyperlink for the given key. It attempts to call the linker function on the
+// given key to get the link target. If the function is nil or the output is
+// empty, just the key (as a non-link) will be returned.
+func markdownLink(key string, linker func(string) string) string {
+	var target string
+	if linker != nil {
+		target = linker(key)
+	}
+
+	if target == "" {
+		// We don't have a link target for this key, so just return the key.
+		return key
+	} else {
+		return fmt.Sprintf("[%s](%s)", key, target)
+	}
+}
+
+// EscapeMarkdown returns a copy of the input string, in which certain special
+// Markdown characters (e.g. < > |) are escaped. These characters can otherwise
+// cause the Markdown to display incorrectly if not escaped.
+func EscapeMarkdown(raw string) string {
+	escapeSeqs := map[rune]string{
+		'<': "&lt;",
+		'>': "&gt;",
+		'&': "&amp;",
+		'|': "&#x7c;",
+	}
+
+	var escaped strings.Builder
+	escaped.Grow(len(raw))
+
+	lines := strings.Split(raw, "\n")
+	for i, line := range lines {
+		if strings.HasPrefix(line, "    ") {
+			// Literal code block - don't escape anything
+			escaped.WriteString(line)
+
+		} else {
+			// Keep track of whether we are inside a code span `...`
+			// If so, don't escape characters
+			insideCodeSpan := false
+
+			for _, c := range line {
+				if c == '`' {
+					insideCodeSpan = !insideCodeSpan
+				}
+
+				if !insideCodeSpan {
+					if escapeSeq, ok := escapeSeqs[c]; ok {
+						escaped.WriteString(escapeSeq)
+						continue
+					}
+				}
+				escaped.WriteRune(c)
+			}
+		}
+
+		if i < len(lines)-1 {
+			escaped.WriteRune('\n')
+		}
+	}
+
+	return escaped.String()
+}

--- a/markdown_test.go
+++ b/markdown_test.go
@@ -1,0 +1,107 @@
+// Copyright 2024 Canonical Ltd.
+// Licensed under the LGPLv3, see LICENCE file for details.
+
+package cmd_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+
+	jc "github.com/juju/testing/checkers"
+	gc "gopkg.in/check.v1"
+
+	"github.com/juju/cmd/v3"
+)
+
+type markdownSuite struct{}
+
+var _ = gc.Suite(&markdownSuite{})
+
+// TestWriteError ensures that the cmd.PrintMarkdown function surfaces errors
+// returned by the writer.
+func (*markdownSuite) TestWriteError(c *gc.C) {
+	expectedErr := errors.New("foo")
+	writer := errorWriter{err: expectedErr}
+	command := &docTestCommand{
+		info: &cmd.Info{},
+	}
+	err := cmd.PrintMarkdown(writer, command, cmd.MarkdownOptions{})
+	c.Assert(err, gc.NotNil)
+	c.Check(err, gc.ErrorMatches, ".*foo")
+}
+
+// errorWriter is an io.Writer that returns an error whenever the Write method
+// is called.
+type errorWriter struct {
+	err error
+}
+
+func (e errorWriter) Write([]byte) (n int, err error) {
+	return 0, e.err
+}
+
+// TestOutput tests that the output of the PrintMarkdown function is
+// fundamentally correct.
+func (*markdownSuite) TestOutput(c *gc.C) {
+	seeAlso := []string{"clouds", "update-cloud", "remove-cloud", "update-credential"}
+	subcommands := map[string]string{
+		"foo": "foo the bar baz",
+		"bar": "bar the baz foo",
+		"baz": "baz the foo bar",
+	}
+
+	command := &docTestCommand{
+		info: &cmd.Info{
+			Name:        "add-cloud",
+			Args:        "<cloud name> [<cloud definition file>]",
+			Purpose:     "Add a cloud definition to Juju.",
+			Doc:         "details for add-cloud...",
+			Examples:    "examples for add-cloud...",
+			SeeAlso:     seeAlso,
+			Aliases:     []string{"new-cloud", "cloud-add"},
+			Subcommands: subcommands,
+		},
+		flags: []testFlag{{
+			name: "force",
+		}, {
+			name:  "file",
+			short: "f",
+		}, {
+			name:  "credential",
+			short: "c",
+		}},
+	}
+
+	// These functions verify the provided argument is in the expected set.
+	linkForCommand := func(s string) string {
+		for _, cmd := range seeAlso {
+			if cmd == s {
+				return "https://docs.com/" + cmd
+			}
+		}
+		c.Fatalf("linkForCommand called with unexpected command %q", s)
+		return ""
+	}
+
+	linkForSubcommand := func(s string) string {
+		_, ok := subcommands[s]
+		if !ok {
+			c.Fatalf("linkForSubcommand called with unexpected subcommand %q", s)
+		}
+		return "https://docs.com/add-cloud/" + s
+	}
+
+	expected, err := os.ReadFile("testdata/add-cloud.md")
+	c.Assert(err, jc.ErrorIsNil)
+
+	var buf bytes.Buffer
+	err = cmd.PrintMarkdown(&buf, command, cmd.MarkdownOptions{
+		Title:             `Command "juju add-cloud"`,
+		UsagePrefix:       "juju ",
+		LinkForCommand:    linkForCommand,
+		LinkForSubcommand: linkForSubcommand,
+	})
+	c.Assert(err, jc.ErrorIsNil)
+	c.Check(buf.String(), gc.Equals, string(expected))
+}

--- a/testdata/add-cloud.md
+++ b/testdata/add-cloud.md
@@ -1,0 +1,30 @@
+# Command "juju add-cloud"
+
+> See also: [clouds](https://docs.com/clouds), [update-cloud](https://docs.com/update-cloud), [remove-cloud](https://docs.com/remove-cloud), [update-credential](https://docs.com/update-credential)
+
+**Aliases:** new-cloud, cloud-add
+
+## Summary
+Add a cloud definition to Juju.
+
+## Usage
+```juju add-cloud [options] <cloud name> [<cloud definition file>]```
+
+### Options
+| Flag | Default | Usage |
+| --- | --- | --- |
+| `-c`, `--credential` | default value for "credential" flag | description for "credential" flag |
+| `-f`, `--file` | default value for "file" flag | description for "file" flag |
+| `--force` | default value for "force" flag | description for "force" flag |
+
+## Examples
+examples for add-cloud...
+
+## Details
+details for add-cloud...
+
+## Subcommands
+- [bar](https://docs.com/add-cloud/bar)
+- [baz](https://docs.com/add-cloud/baz)
+- [foo](https://docs.com/add-cloud/foo)
+


### PR DESCRIPTION
## Motivation

The juju/cmd library already includes a way to format a given command as Markdown. However, currently this is buried deep inside the implementation details of the internal `documentation` command. As a result, given just a `cmd.Command`, it is not easy to print a Markdown document for it.

To get around this, we have had to use nasty hacks, such as for the hook tools, where we created a "fake"/artificial supercommand for the hook tools and ran the embedded documentation command to generate the docs.
https://github.com/juju/juju/blob/0ae8f81a9e5ecc3a50c35ea059861a000f3c6657/scripts/md-gen/hook-tools/main.go#L43-L60

## Changes

This PR refactors this code to expose a top-level `PrintMarkdown` function. This function takes three arguments:
- the `cmd.Command` to print the Markdown for;
- an `io.Writer` which all output is printed to;
- a `MarkdownOptions` struct whose values affect the outputted Markdown. The intent is that more fields can be added to this struct in response to future needs, while maintaining backward compability. Currently the options include:
  - whether or not to print a title
  - a prefix for the command usage (in our case this would be `"juju "`, as the supercommand name is not stored in the command)
  - functions to provide link targets for command names. These generally depend on the environment and context in which we are generating the documentation.

As we continue to move towards generated documentation, this new function should make the generation much easier. For example, there are other `cmd.Command` implementations in juju (such as the agent introspection tools) which we want to create docs for. The intention furthermore is that the existing `documentation` command will be refactored to use this function internally.

I'm not guaranteeing the output will be exactly the same as before, but it should have parity information-wise and at least not regress in any way in terms of formatting.

As this PR extends the public API of this package in a backwards-compatible way, it may necessitate a new minor release v3.1.0.

## Example usage

An example usage of this function could be:
```go
file, err := os.Create("mydoc.md")
cmd.PrintMarkdown(file, &myCommand, cmd.MarkdownOptions{})
file.Close()
```

## Documentation changes

Minor changes to generated Markdown:
- All generated Markdown docs previously had a redundant horizontal line at the end. This has now been removed.
- Command aliases are printed.

## QA

Pull the 3.5 branch of juju/juju. Build the client and generate the documentation.
```
make go-client-build
juju documentation --split --out=./docs
```
Commit the generated documentation so we can compare it with the new docs.

Pull this branch of juju/cmd. In the root directory of the juju/juju/3.5 branch, create a go.work file:
```
go work init .
go work edit -replace=github.com/juju/cmd/v3=[path/to/this/branch]
```

Rebuild the Juju client:
```
make go-client-build
```

Now delete the ./docs folder and regenerate the documentation to see the changes.

## TODO
- [x] error handling
- [x] unit tests
- [x] QA with Juju, check diff with current documentation

## Links

Jira card: [JUJU-6627](https://warthogs.atlassian.net/browse/JUJU-6627)

[JUJU-6627]: https://warthogs.atlassian.net/browse/JUJU-6627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ