### PR TITLE
chore: update doc heading

### DIFF
--- a/documentation.go
+++ b/documentation.go
@@ -357,7 +357,7 @@ func (c *documentationCommand) linkForCommand(cmd string) string {
 func (c *documentationCommand) formatCommand(ref commandReference, title bool, commandSeq []string) string {
 	var fmtedTitle string
 	if title {
-		fmtedTitle = strings.ToUpper(strings.Join(commandSeq[1:], " "))
+		fmtedTitle = strings.ToLower(strings.Join(commandSeq, " "))
 	}
 
 	var buf bytes.Buffer


### PR DESCRIPTION
This PR updates the documentation markdown generator. Specifically, it changes document headings from UpperCase(<sub-command>) to LowerCase(<base-command> <sub-command>).

E.g. a command like `juju add-controller` would include a title of `ADD-CONTROLLER` but with this change becomes `juju add-controller` and better reflects the CLI usage. 
This shouldn't affect Juju documentation because there the title is often excluded since each command is documented on a different page, but for other tools using this package the title is more useful.

This change was prompted by the `jimmctl` reference docs at https://canonical-jaas-documentation.readthedocs-hosted.com/en/latest/reference/jimmctl/ cc @tmihoc 

Partially fixes [JUJU-7372](https://warthogs.atlassian.net/browse/JUJU-7372)

[JUJU-7372]: https://warthogs.atlassian.net/browse/JUJU-7372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ