### PR TITLE
feat: ignore doc aliases when generating split docs

### DIFF
--- a/documentation.go
+++ b/documentation.go
@@ -185,6 +185,9 @@ func (c *documentationCommand) writeDocs(folder string, superCommands []string, 
 		if !printDefaultCommands && isDefaultCommand(name) {
 			continue
 		}
+		if ref.alias != "" {
+			continue
+		}
 
 		commandSeq := append(superCommands, name)
 


### PR DESCRIPTION
A previous [PR](https://github.com/juju/cmd/pull/127) added code to ignore doc aliases. However, it turns out there's a different code path when generating split docs. This PR fixes that.